### PR TITLE
Transaction execution

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -319,8 +319,12 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})
 	gaspool := new(core.GasPool).AddGas(math.MaxUint64)
+	var gp1559 *core.GasPool
+	if b.config.IsEIP1559(block.Number()) {
+		gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
 
-	return core.NewStateTransition(vmenv, msg, gaspool).TransitionDb()
+	return core.NewStateTransition(vmenv, msg, gaspool, gp1559).TransitionDb()
 }
 
 // SendTransaction updates the pending block to include the given transaction.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -455,6 +455,8 @@ func (m callmsg) GasPrice() *big.Int   { return m.CallMsg.GasPrice }
 func (m callmsg) Gas() uint64          { return m.CallMsg.Gas }
 func (m callmsg) Value() *big.Int      { return m.CallMsg.Value }
 func (m callmsg) Data() []byte         { return m.CallMsg.Data }
+func (m callmsg) GasPremium() *big.Int { return m.CallMsg.GasPremium }
+func (m callmsg) FeeCap() *big.Int     { return m.CallMsg.FeeCap }
 
 // filterBackend implements filters.Backend to support filtering for logs without
 // taking bloom-bits acceleration structures into account.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -300,14 +300,14 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallMsg, block *types.Block, statedb *state.StateDB) ([]byte, uint64, bool, error) {
 	// Ensure message is initialized properly.
 	// EIP1559 guards
-	if b.config.IsEIP1559Finalized(block.Number()) && call.GasPremium == nil || call.FeeCap == nil || call.GasPrice != nil {
-		return nil, 0, false, fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", b.config.EIP1559FinalizedBlock.Uint64())
+	if b.config.IsEIP1559Finalized(block.Number()) && (call.GasPremium == nil || call.FeeCap == nil || call.GasPrice != nil) {
+		return nil, 0, false, core.ErrTxNotEIP1559
 	}
-	if !b.config.IsEIP1559(block.Number()) && call.GasPremium != nil || call.FeeCap != nil || call.GasPrice == nil {
-		return nil, 0, false, fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", b.config.EIP1559Block.Uint64())
+	if !b.config.IsEIP1559(block.Number()) && (call.GasPremium != nil || call.FeeCap != nil || call.GasPrice == nil) {
+		return nil, 0, false, core.ErrTxIsEIP1559
 	}
 	if call.GasPrice != nil && (call.GasPremium != nil || call.FeeCap != nil) {
-		return nil, 0, false, errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+		return nil, 0, false, core.ErrTxSetsLegacyAndEIP1559Fields
 	}
 	if call.FeeCap != nil && call.GasPremium == nil {
 		return nil, 0, false, errors.New("if FeeCap is set, GasPremium must be set")
@@ -350,23 +350,17 @@ func (b *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transa
 	defer b.mu.Unlock()
 
 	// EIP1559 guards
-	if b.config.IsEIP1559Finalized(b.blockchain.CurrentBlock().Number()) && tx.GasPremium() == nil || tx.FeeCap() == nil || tx.GasPrice() != nil {
-		return fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", b.config.EIP1559FinalizedBlock.Uint64())
+	if b.config.IsEIP1559Finalized(b.blockchain.CurrentBlock().Number()) && (tx.GasPremium() == nil || tx.FeeCap() == nil || tx.GasPrice() != nil) {
+		return core.ErrTxNotEIP1559
 	}
-	if !b.config.IsEIP1559(b.blockchain.CurrentBlock().Number()) && tx.GasPremium() != nil || tx.FeeCap() != nil || tx.GasPrice() == nil {
-		return fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", b.config.EIP1559Block.Uint64())
+	if !b.config.IsEIP1559(b.blockchain.CurrentBlock().Number()) && (tx.GasPremium() != nil || tx.FeeCap() != nil || tx.GasPrice() == nil) {
+		return core.ErrTxIsEIP1559
 	}
 	if tx.GasPrice() != nil && (tx.GasPremium() != nil || tx.FeeCap() != nil) {
-		return errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+		return core.ErrTxSetsLegacyAndEIP1559Fields
 	}
-	if tx.FeeCap() != nil && tx.GasPremium() == nil {
-		return errors.New("if FeeCap is set, GasPremium must be set")
-	}
-	if tx.GasPremium() != nil && tx.FeeCap() == nil {
-		return errors.New("if GasPremium is set, FeeCap must be set")
-	}
-	if tx.GasPrice() == nil && tx.GasPremium() == nil {
-		return errors.New("either GasPrice or GasPremium and FeeCap need to be set")
+	if tx.GasPrice() == nil && (tx.GasPremium() == nil || tx.FeeCap() == nil) {
+		return core.ErrMissingGasFields
 	}
 
 	sender, err := types.Sender(types.NewEIP155Signer(b.config.ChainID), tx)

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -299,7 +299,23 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 // state is modified during execution, make sure to copy it if necessary.
 func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallMsg, block *types.Block, statedb *state.StateDB) ([]byte, uint64, bool, error) {
 	// Ensure message is initialized properly.
-	if call.GasPrice == nil {
+	// EIP1559 guards
+	if b.config.IsEIP1559Finalized(block.Number()) && call.GasPremium == nil || call.FeeCap == nil || call.GasPrice != nil {
+		return nil, 0, false, fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", b.config.EIP1559FinalizedBlock.Uint64())
+	}
+	if !b.config.IsEIP1559(block.Number()) && call.GasPremium != nil || call.FeeCap != nil || call.GasPrice == nil {
+		return nil, 0, false, fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", b.config.EIP1559Block.Uint64())
+	}
+	if call.GasPrice != nil && (call.GasPremium != nil || call.FeeCap != nil) {
+		return nil, 0, false, errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+	}
+	if call.FeeCap != nil && call.GasPremium == nil {
+		return nil, 0, false, errors.New("if FeeCap is set, GasPremium must be set")
+	}
+	if call.GasPremium != nil && call.FeeCap == nil {
+		return nil, 0, false, errors.New("if GasPremium is set, FeeCap must be set")
+	}
+	if call.GasPrice == nil && call.GasPremium == nil {
 		call.GasPrice = big.NewInt(1)
 	}
 	if call.Gas == 0 {
@@ -332,6 +348,26 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 func (b *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	// EIP1559 guards
+	if b.config.IsEIP1559Finalized(b.blockchain.CurrentBlock().Number()) && tx.GasPremium() == nil || tx.FeeCap() == nil || tx.GasPrice() != nil {
+		return fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", b.config.EIP1559FinalizedBlock.Uint64())
+	}
+	if !b.config.IsEIP1559(b.blockchain.CurrentBlock().Number()) && tx.GasPremium() != nil || tx.FeeCap() != nil || tx.GasPrice() == nil {
+		return fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", b.config.EIP1559Block.Uint64())
+	}
+	if tx.GasPrice() != nil && (tx.GasPremium() != nil || tx.FeeCap() != nil) {
+		return errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+	}
+	if tx.FeeCap() != nil && tx.GasPremium() == nil {
+		return errors.New("if FeeCap is set, GasPremium must be set")
+	}
+	if tx.GasPremium() != nil && tx.FeeCap() == nil {
+		return errors.New("if GasPremium is set, FeeCap must be set")
+	}
+	if tx.GasPrice() == nil && tx.GasPremium() == nil {
+		return errors.New("either GasPrice or GasPremium and FeeCap need to be set")
+	}
 
 	sender, err := types.Sender(types.NewEIP155Signer(b.config.ChainID), tx)
 	if err != nil {

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -54,7 +54,7 @@ func TestSimulatedBackend(t *testing.T) {
 	// generate a transaction and confirm you can retrieve it
 	code := `6060604052600a8060106000396000f360606040526008565b00`
 	var gas uint64 = 3000000
-	tx := types.NewContractCreation(0, big.NewInt(0), gas, big.NewInt(1), common.FromHex(code))
+	tx := types.NewContractCreation(0, big.NewInt(0), gas, big.NewInt(1), common.FromHex(code), nil, nil)
 	tx, _ = types.SignTx(tx, types.HomesteadSigner{}, key)
 
 	err = sim.SendTransaction(context.Background(), tx)

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -227,9 +227,9 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	// Create the transaction, sign it and schedule it for execution
 	var rawTx *types.Transaction
 	if contract == nil {
-		rawTx = types.NewContractCreation(nonce, value, gasLimit, gasPrice, input)
+		rawTx = types.NewContractCreation(nonce, value, gasLimit, gasPrice, input, nil, nil)
 	} else {
-		rawTx = types.NewTransaction(nonce, c.address, value, gasLimit, gasPrice, input)
+		rawTx = types.NewTransaction(nonce, c.address, value, gasLimit, gasPrice, input, nil, nil)
 	}
 	if opts.Signer == nil {
 		return nil, errors.New("no signer to authorize the transaction with")

--- a/accounts/abi/bind/util_test.go
+++ b/accounts/abi/bind/util_test.go
@@ -62,7 +62,7 @@ func TestWaitDeployed(t *testing.T) {
 		defer backend.Close()
 
 		// Create the transaction.
-		tx := types.NewContractCreation(0, big.NewInt(0), test.gas, big.NewInt(1), common.FromHex(test.code))
+		tx := types.NewContractCreation(0, big.NewInt(0), test.gas, big.NewInt(1), common.FromHex(test.code), nil, nil)
 		tx, _ = types.SignTx(tx, types.HomesteadSigner{}, testKey)
 
 		// Wait for it to get mined in the background.

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -775,6 +775,7 @@ func testExternalUI(api *core.SignerAPI) {
 			[]byte("Extra data Extra data Extra data  Extra data  Extra data  Extra data  Extra data Extra data"),
 			common.HexToHash("0x0000H45H"),
 			types.BlockNonce{},
+			nil,
 		}
 		cliqueRlp, err := rlp.EncodeToBytes(cliqueHeader)
 		if err != nil {

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -481,7 +481,7 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 			amount = new(big.Int).Mul(amount, new(big.Int).Exp(big.NewInt(5), big.NewInt(int64(msg.Tier)), nil))
 			amount = new(big.Int).Div(amount, new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(msg.Tier)), nil))
 
-			tx := types.NewTransaction(f.nonce+uint64(len(f.reqs)), address, amount, 21000, f.price, nil)
+			tx := types.NewTransaction(f.nonce+uint64(len(f.reqs)), address, amount, 21000, f.price, nil, nil, nil)
 			signed, err := f.keystore.SignTx(f.account, tx, f.config.ChainID)
 			if err != nil {
 				f.lock.Unlock()

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -492,6 +492,10 @@ func (api *RetestethAPI) mineBlock() error {
 		misc.ApplyDAOHardFork(statedb)
 	}
 	gasPool := new(core.GasPool).AddGas(header.GasLimit)
+	var gp1559 *core.GasPool
+	if api.chainConfig.IsEIP1559(header.Number) {
+		gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
 	txCount := 0
 	var txs []*types.Transaction
 	var receipts []*types.Receipt
@@ -513,6 +517,7 @@ func (api *RetestethAPI) mineBlock() error {
 					api.blockchain,
 					&api.author,
 					gasPool,
+					gp1559,
 					statedb,
 					header, tx, &header.GasUsed, *api.blockchain.GetVMConfig(),
 				)
@@ -657,7 +662,11 @@ func (api *RetestethAPI) AccountRange(ctx context.Context,
 			context := core.NewEVMContext(msg, block.Header(), api.blockchain, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
-			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+			var gp1559 *core.GasPool
+			if vmenv.ChainConfig().IsEIP1559(block.Number()) {
+				gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+			}
+			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()), gp1559); err != nil {
 				return AccountRangeResult{}, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 			}
 			// Ensure any modifications are committed to the state
@@ -770,7 +779,11 @@ func (api *RetestethAPI) StorageRangeAt(ctx context.Context,
 			context := core.NewEVMContext(msg, block.Header(), api.blockchain, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
-			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+			var gp1559 *core.GasPool
+			if vmenv.ChainConfig().IsEIP1559(block.Number()) {
+				gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+			}
+			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()), gp1559); err != nil {
 				return StorageRangeResult{}, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 			}
 			// Ensure any modifications are committed to the state

--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -65,7 +65,7 @@ func TestReimportMirroredState(t *testing.T) {
 		// We want to simulate an empty middle block, having the same state as the
 		// first one. The last is needs a state change again to force a reorg.
 		if i != 1 {
-			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(addr), common.Address{0x00}, new(big.Int), params.TxGas, nil, nil), signer, key)
+			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(addr), common.Address{0x00}, new(big.Int), params.TxGas, nil, nil, nil, nil), signer, key)
 			if err != nil {
 				panic(err)
 			}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -86,7 +86,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
 		gas, _ := IntrinsicGas(data, false, false, false)
-		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, data), types.HomesteadSigner{}, benchRootKey)
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, data, nil, nil), types.HomesteadSigner{}, benchRootKey)
 		gen.AddTx(tx)
 	}
 }
@@ -124,6 +124,8 @@ func genTxRing(naccounts int) func(int, *BlockGen) {
 				ringAddrs[to],
 				benchRootFunds,
 				params.TxGas,
+				nil,
+				nil,
 				nil,
 				nil,
 			)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -606,7 +606,7 @@ func TestFastVsFullChains(t *testing.T) {
 		// If the block number is multiple of 3, send a few bonus transactions to the miner
 		if i%3 == 2 {
 			for j := 0; j < i%4+1; j++ {
-				tx, err := types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{0x00}, big.NewInt(1000), params.TxGas, nil, nil), signer, key)
+				tx, err := types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{0x00}, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key)
 				if err != nil {
 					panic(err)
 				}
@@ -839,8 +839,8 @@ func TestChainTxReorgs(t *testing.T) {
 	// Create two transactions shared between the chains:
 	//  - postponed: transaction included at a later block in the forked chain
 	//  - swapped: transaction included at the same block number in the forked chain
-	postponed, _ := types.SignTx(types.NewTransaction(0, addr1, big.NewInt(1000), params.TxGas, nil, nil), signer, key1)
-	swapped, _ := types.SignTx(types.NewTransaction(1, addr1, big.NewInt(1000), params.TxGas, nil, nil), signer, key1)
+	postponed, _ := types.SignTx(types.NewTransaction(0, addr1, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key1)
+	swapped, _ := types.SignTx(types.NewTransaction(1, addr1, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key1)
 
 	// Create two transactions that will be dropped by the forked chain:
 	//  - pastDrop: transaction dropped retroactively from a past block
@@ -856,13 +856,13 @@ func TestChainTxReorgs(t *testing.T) {
 	chain, _ := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), db, 3, func(i int, gen *BlockGen) {
 		switch i {
 		case 0:
-			pastDrop, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr2, big.NewInt(1000), params.TxGas, nil, nil), signer, key2)
+			pastDrop, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr2, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key2)
 
 			gen.AddTx(pastDrop)  // This transaction will be dropped in the fork from below the split point
 			gen.AddTx(postponed) // This transaction will be postponed till block #3 in the fork
 
 		case 2:
-			freshDrop, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr2, big.NewInt(1000), params.TxGas, nil, nil), signer, key2)
+			freshDrop, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr2, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key2)
 
 			gen.AddTx(freshDrop) // This transaction will be dropped in the fork from exactly at the split point
 			gen.AddTx(swapped)   // This transaction will be swapped out at the exact height
@@ -881,18 +881,18 @@ func TestChainTxReorgs(t *testing.T) {
 	chain, _ = GenerateChain(gspec.Config, genesis, ethash.NewFaker(), db, 5, func(i int, gen *BlockGen) {
 		switch i {
 		case 0:
-			pastAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil), signer, key3)
+			pastAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key3)
 			gen.AddTx(pastAdd) // This transaction needs to be injected during reorg
 
 		case 2:
 			gen.AddTx(postponed) // This transaction was postponed from block #1 in the original chain
 			gen.AddTx(swapped)   // This transaction was swapped from the exact current spot in the original chain
 
-			freshAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil), signer, key3)
+			freshAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key3)
 			gen.AddTx(freshAdd) // This transaction will be added exactly at reorg time
 
 		case 3:
-			futureAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil), signer, key3)
+			futureAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key3)
 			gen.AddTx(futureAdd) // This transaction will be added after a full reorg
 		}
 	})
@@ -948,7 +948,7 @@ func TestLogReorgs(t *testing.T) {
 	blockchain.SubscribeRemovedLogsEvent(rmLogsCh)
 	chain, _ := GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		if i == 1 {
-			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code), signer, key1)
+			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code, nil, nil), signer, key1)
 			if err != nil {
 				t.Fatalf("failed to create tx: %v", err)
 			}
@@ -1029,7 +1029,7 @@ func TestLogRebirth(t *testing.T) {
 
 	chain, _ := GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		if i == 1 {
-			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code), signer, key1)
+			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code, nil, nil), signer, key1)
 			if err != nil {
 				t.Fatalf("failed to create tx: %v", err)
 			}
@@ -1049,7 +1049,7 @@ func TestLogRebirth(t *testing.T) {
 	// Generate long reorg chain
 	forkChain, _ := GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		if i == 1 {
-			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code), signer, key1)
+			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code, nil, nil), signer, key1)
 			if err != nil {
 				t.Fatalf("failed to create tx: %v", err)
 			}
@@ -1159,7 +1159,7 @@ func TestSideLogRebirth(t *testing.T) {
 	// Generate side chain with lower difficulty
 	sideChain, _ := GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		if i == 1 {
-			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code), signer, key1)
+			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code, nil, nil), signer, key1)
 			if err != nil {
 				t.Fatalf("failed to create tx: %v", err)
 			}
@@ -1204,7 +1204,7 @@ func TestReorgSideEvent(t *testing.T) {
 	}
 
 	replacementBlocks, _ := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), db, 4, func(i int, gen *BlockGen) {
-		tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), nil), signer, key1)
+		tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), nil, nil, nil), signer, key1)
 		if i == 2 {
 			gen.OffsetTime(-9)
 		}
@@ -1332,7 +1332,7 @@ func TestEIP155Transition(t *testing.T) {
 			tx      *types.Transaction
 			err     error
 			basicTx = func(signer types.Signer) (*types.Transaction, error) {
-				return types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{}, new(big.Int), 21000, new(big.Int), nil), signer, key)
+				return types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{}, new(big.Int), 21000, new(big.Int), nil, nil, nil), signer, key)
 			}
 		)
 		switch i {
@@ -1395,7 +1395,7 @@ func TestEIP155Transition(t *testing.T) {
 			tx      *types.Transaction
 			err     error
 			basicTx = func(signer types.Signer) (*types.Transaction, error) {
-				return types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{}, new(big.Int), 21000, new(big.Int), nil), signer, key)
+				return types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{}, new(big.Int), 21000, new(big.Int), nil, nil, nil), signer, key)
 			}
 		)
 		if i == 0 {
@@ -1443,11 +1443,11 @@ func TestEIP161AccountRemoval(t *testing.T) {
 		)
 		switch i {
 		case 0:
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), theAddr, new(big.Int), 21000, new(big.Int), nil), signer, key)
+			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), theAddr, new(big.Int), 21000, new(big.Int), nil, nil, nil), signer, key)
 		case 1:
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), theAddr, new(big.Int), 21000, new(big.Int), nil), signer, key)
+			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), theAddr, new(big.Int), 21000, new(big.Int), nil, nil, nil), signer, key)
 		case 2:
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), theAddr, new(big.Int), 21000, new(big.Int), nil), signer, key)
+			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), theAddr, new(big.Int), 21000, new(big.Int), nil, nil, nil), signer, key)
 		}
 		if err != nil {
 			t.Fatal(err)
@@ -2163,7 +2163,7 @@ func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks in
 		for txi := 0; txi < numTxs; txi++ {
 			uniq := uint64(i*numTxs + txi)
 			recipient := recipientFn(uniq)
-			tx, err := types.SignTx(types.NewTransaction(uniq, recipient, big.NewInt(1), params.TxGas, big.NewInt(1), nil), signer, testBankKey)
+			tx, err := types.SignTx(types.NewTransaction(uniq, recipient, big.NewInt(1), params.TxGas, big.NewInt(1), nil, nil, nil), signer, testBankKey)
 			if err != nil {
 				b.Error(err)
 			}
@@ -2344,11 +2344,11 @@ func TestDeleteCreateRevert(t *testing.T) {
 		b.SetCoinbase(common.Address{1})
 		// One transaction to AAAA
 		tx, _ := types.SignTx(types.NewTransaction(0, aa,
-			big.NewInt(0), 50000, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+			big.NewInt(0), 50000, big.NewInt(1), nil, nil, nil), types.HomesteadSigner{}, key)
 		b.AddTx(tx)
 		// One transaction to BBBB
 		tx, _ = types.SignTx(types.NewTransaction(1, bb,
-			big.NewInt(0), 100000, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+			big.NewInt(0), 100000, big.NewInt(1), nil, nil, nil), types.HomesteadSigner{}, key)
 		b.AddTx(tx)
 	})
 	// Import the canonical chain

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -54,13 +54,13 @@ func ExampleGenerateChain() {
 		switch i {
 		case 0:
 			// In block 1, addr1 sends addr2 some ether.
-			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
+			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), signer, key1)
 			gen.AddTx(tx)
 		case 1:
 			// In block 2, addr1 sends some more ether to addr2.
 			// addr2 passes it on to addr3.
-			tx1, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(1000), params.TxGas, nil, nil), signer, key1)
-			tx2, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr3, big.NewInt(1000), params.TxGas, nil, nil), signer, key2)
+			tx1, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key1)
+			tx2, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr3, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, key2)
 			gen.AddTx(tx1)
 			gen.AddTx(tx2)
 		case 2:

--- a/core/evm.go
+++ b/core/evm.go
@@ -55,6 +55,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 		Difficulty:  new(big.Int).Set(header.Difficulty),
 		GasLimit:    header.GasLimit,
 		GasPrice:    new(big.Int).Set(msg.GasPrice()),
+		BaseFee:     header.BaseFee,
 	}
 }
 

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -271,8 +271,8 @@ func TestBlockReceiptStorage(t *testing.T) {
 	db := NewMemoryDatabase()
 
 	// Create a live block since we need metadata to reconstruct the receipt
-	tx1 := types.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil)
-	tx2 := types.NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil)
+	tx1 := types.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil, nil, nil)
+	tx2 := types.NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil, nil, nil)
 
 	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
 

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -66,9 +66,9 @@ func TestLookupStorage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			db := NewMemoryDatabase()
 
-			tx1 := types.NewTransaction(1, common.BytesToAddress([]byte{0x11}), big.NewInt(111), 1111, big.NewInt(11111), []byte{0x11, 0x11, 0x11})
-			tx2 := types.NewTransaction(2, common.BytesToAddress([]byte{0x22}), big.NewInt(222), 2222, big.NewInt(22222), []byte{0x22, 0x22, 0x22})
-			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
+			tx1 := types.NewTransaction(1, common.BytesToAddress([]byte{0x11}), big.NewInt(111), 1111, big.NewInt(11111), []byte{0x11, 0x11, 0x11}, nil, nil)
+			tx2 := types.NewTransaction(2, common.BytesToAddress([]byte{0x22}), big.NewInt(222), 2222, big.NewInt(22222), []byte{0x22, 0x22, 0x22}, nil, nil)
+			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33}, nil, nil)
 			txs := []*types.Transaction{tx1, tx2, tx3}
 
 			block := types.NewBlock(&types.Header{Number: big.NewInt(314)}, txs, nil, nil)

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -52,7 +52,11 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 	var (
 		header  = block.Header()
 		gaspool = new(GasPool).AddGas(block.GasLimit())
+		gp1559  *GasPool
 	)
+	if p.config.IsEIP1559(block.Number()) {
+		gp1559 = new(GasPool).AddGas(params.MaxGasEIP1559)
+	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		// If block precaching was interrupted, abort
@@ -61,7 +65,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		}
 		// Block precaching permitted to continue, execute the transaction
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
-		if err := precacheTransaction(p.config, p.bc, nil, gaspool, statedb, header, tx, cfg); err != nil {
+		if err := precacheTransaction(p.config, p.bc, nil, gaspool, gp1559, statedb, header, tx, cfg); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}
 	}
@@ -70,7 +74,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 // precacheTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. The goal is not to execute
 // the transaction successfully, rather to warm up touched data slots.
-func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gaspool *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
+func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gaspool, gp1559 *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
 	// Convert the transaction into an executable message and pre-cache its sender
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
 	if err != nil {
@@ -80,6 +84,6 @@ func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *co
 	context := NewEVMContext(msg, header, bc, author)
 	vm := vm.NewEVM(context, statedb, config, cfg)
 
-	_, _, _, err = ApplyMessage(vm, msg, gaspool)
+	_, _, _, err = ApplyMessage(vm, msg, gaspool, gp1559)
 	return err
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -60,7 +60,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		header   = block.Header()
 		allLogs  []*types.Log
 		gp       = new(GasPool).AddGas(block.GasLimit())
+		gp1559   *GasPool
 	)
+	if p.config.IsEIP1559(block.Number()) {
+		gp1559 = new(GasPool).AddGas(params.MaxGasEIP1559)
+	}
 	// Mutate the block and state according to any hard-fork specs
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
@@ -68,7 +72,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
-		receipt, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg)
+		receipt, err := ApplyTransaction(p.config, p.bc, nil, gp, gp1559, statedb, header, tx, usedGas, cfg)
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -85,7 +89,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
+func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp, gp1559 *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
 	if err != nil {
 		return nil, err
@@ -96,7 +100,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(context, statedb, config, cfg)
 	// Apply the transaction to the current state (included in the env)
-	_, gas, failed, err := ApplyMessage(vmenv, msg, gp)
+	_, gas, failed, err := ApplyMessage(vmenv, msg, gp, gp1559)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -50,17 +50,18 @@ The state transitioning model does all the necessary work to work out a valid ne
 6) Derive new state root
 */
 type StateTransition struct {
-	gp         *GasPool
-	gp1559     *GasPool
-	msg        Message
-	gas        uint64
-	gasPrice   *big.Int
-	initialGas uint64
-	value      *big.Int
-	data       []byte
-	state      vm.StateDB
-	evm        *vm.EVM
-	isEIP1559  bool
+	gp              *GasPool
+	gp1559          *GasPool
+	msg             Message
+	gas             uint64
+	gasPrice        *big.Int
+	initialGas      uint64
+	value           *big.Int
+	data            []byte
+	state           vm.StateDB
+	evm             *vm.EVM
+	isEIP1559       bool
+	eip1559GasPrice *big.Int
 }
 
 // Message represents a message sent to a contract.
@@ -121,10 +122,7 @@ func IntrinsicGas(data []byte, contractCreation, isEIP155 bool, isEIP2028 bool) 
 // NewStateTransition initialises and returns a new state transition object.
 func NewStateTransition(evm *vm.EVM, msg Message, gp, gp1559 *GasPool) *StateTransition {
 	isEIP1559 := evm.ChainConfig().IsEIP1559(evm.BlockNumber) && msg.GasPremium() != nil && msg.FeeCap() != nil && evm.BaseFee != nil && gp1559 != nil
-	// check that msg doesn't try to set both legacy and 1559 params
-	// check that legacy has legacy params set
-	// reject 1559 trxs if we are before the 1559 fork blocknumber
-	return &StateTransition{
+	st := &StateTransition{
 		gp:        gp,
 		gp1559:    gp1559,
 		evm:       evm,
@@ -135,6 +133,14 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp, gp1559 *GasPool) *StateTra
 		state:     evm.StateDB,
 		isEIP1559: isEIP1559,
 	}
+	if isEIP1559 {
+		// EP1559 gasPrice = min(BASEFEE + tx.fee_premium, tx.fee_cap)
+		st.eip1559GasPrice = new(big.Int).Add(evm.BaseFee, msg.GasPremium())
+		if st.eip1559GasPrice.Cmp(msg.FeeCap()) > 0 {
+			st.eip1559GasPrice.Set(msg.FeeCap())
+		}
+	}
+	return st
 }
 
 // ApplyMessage computes the new state by applying the given message
@@ -173,13 +179,8 @@ func (st *StateTransition) buyGas() error {
 }
 
 func (st *StateTransition) buyGasEIP1559() error {
-	// gasPrice = min(BASEFEE + tx.fee_premium, tx.fee_cap)
-	gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
-	if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
-		gasPrice.Set(st.msg.FeeCap())
-	}
 	// tx.origin pays gasPrice * tx.gas
-	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), gasPrice)
+	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.eip1559GasPrice)
 	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
 		return errInsufficientBalanceForGas
 	}
@@ -218,9 +219,25 @@ func (st *StateTransition) preCheck() error {
 			return ErrNonceTooLow
 		}
 	}
-	// If we are past the EIP1559 finalization block and this transaction does not conform with EIP1559, throw an error
+	// If we have reached the EIP1559 finalization block and we do not conform with EIP1559, throw an error
 	if st.evm.ChainConfig().IsEIP1559Finalized(st.evm.BlockNumber) && !st.isEIP1559 {
 		return ErrTxNotEIP1559
+	}
+	// If we are before the EIP1559 initialization block, throw an error if we have EIP1559 fields or do not have a GasPrice
+	if !st.evm.ChainConfig().IsEIP1559(st.evm.BlockNumber) && (st.msg.GasPremium() != nil || st.msg.FeeCap() != nil || st.gp1559 != nil || st.evm.BaseFee != nil || st.msg.GasPrice() == nil) {
+		return ErrTxIsEIP1559
+	}
+	// If transaction has both legacy and EIP1559 fields, throw an error
+	if (st.msg.GasPremium() != nil || st.msg.FeeCap() != nil) && st.msg.GasPrice() != nil {
+		return ErrTxSetsLegacyAndEIP1559Fields
+	}
+	// We need a BaseFee if we are past EIP1559 initialization
+	if st.evm.ChainConfig().IsEIP1559(st.evm.BlockNumber) && st.evm.BaseFee == nil {
+		return ErrNoBaseFee
+	}
+	// We need either a GasPrice or a FeeCap and GasPremium to be set
+	if st.msg.GasPrice() == nil && (st.msg.GasPremium() == nil || st.msg.FeeCap() == nil) {
+		return ErrMissingGasFields
 	}
 	return st.buyGas()
 }
@@ -272,12 +289,8 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	}
 	st.refundGas()
 	if st.isEIP1559 {
-		gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
-		if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
-			gasPrice.Set(st.msg.FeeCap())
-		}
 		// block.coinbase gains (gasprice - BASEFEE) * gasused
-		coinBaseCredit := new(big.Int).Mul(new(big.Int).Sub(gasPrice, st.evm.BaseFee), new(big.Int).SetUint64(st.gasUsed()))
+		coinBaseCredit := new(big.Int).Mul(new(big.Int).Sub(st.eip1559GasPrice, st.evm.BaseFee), new(big.Int).SetUint64(st.gasUsed()))
 		//  If gasprice < BASEFEE (due to the fee_cap), this means that the block.coinbase loses funds from this operation;
 		//  in this case, check that the post-balance is non-negative and throw an exception if it is negative.
 		if coinBaseCredit.Sign() < 0 {
@@ -287,7 +300,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 				return nil, 0, vmerr != nil, errInsufficientCoinbaseBalance
 			}
 		}
-		st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), gasPrice))
+		st.state.AddBalance(st.evm.Coinbase, coinBaseCredit)
 
 		return ret, st.gasUsed(), vmerr != nil, err
 	}
@@ -331,13 +344,7 @@ func (st *StateTransition) refundGasEIP1559() {
 
 	// tx.origin gets refunded gasprice * (tx.gas - gasused)
 	txGasSubUsed := new(big.Int).Sub(new(big.Int).SetUint64(st.msg.Gas()), new(big.Int).SetUint64(st.gasUsed()))
-
-	// gasPrice = min(BASEFEE + tx.fee_premium, tx.fee_cap)
-	gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
-	if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
-		gasPrice.Set(st.msg.FeeCap())
-	}
-	remaining := new(big.Int).Mul(gasPrice, txGasSubUsed)
+	remaining := new(big.Int).Mul(st.eip1559GasPrice, txGasSubUsed)
 	st.state.AddBalance(st.msg.From(), remaining)
 
 	// Also return remaining gas to the block gas counter so it is

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -73,6 +73,9 @@ type Message interface {
 	Nonce() uint64
 	CheckNonce() bool
 	Data() []byte
+
+	GasPremium() *big.Int
+	FeeCap() *big.Int
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -28,7 +28,8 @@ import (
 )
 
 var (
-	errInsufficientBalanceForGas = errors.New("insufficient balance to pay for gas")
+	errInsufficientBalanceForGas   = errors.New("insufficient balance to pay for gas")
+	errInsufficientCoinbaseBalance = errors.New("insufficient coinbase balance to apply a negative coinbase credit")
 )
 
 /*
@@ -172,11 +173,12 @@ func (st *StateTransition) buyGas() error {
 }
 
 func (st *StateTransition) buyGasEIP1559() error {
-	// any reason we can't set st.gasPrice to this?
+	// gasPrice = min(BASEFEE + tx.fee_premium, tx.fee_cap)
 	gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
 	if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
 		gasPrice.Set(st.msg.FeeCap())
 	}
+	// tx.origin pays gasPrice * tx.gas
 	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), gasPrice)
 	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
 		return errInsufficientBalanceForGas
@@ -269,10 +271,21 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
-	if st.isEIP1559 { // if we can set st.gasPrice to the calculated eip1559 gasPrice in buyGas then we don't need this
+	if st.isEIP1559 {
 		gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
 		if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
 			gasPrice.Set(st.msg.FeeCap())
+		}
+		// block.coinbase gains (gasprice - BASEFEE) * gasused
+		coinBaseCredit := new(big.Int).Mul(new(big.Int).Sub(gasPrice, st.evm.BaseFee), new(big.Int).SetUint64(st.gasUsed()))
+		//  If gasprice < BASEFEE (due to the fee_cap), this means that the block.coinbase loses funds from this operation;
+		//  in this case, check that the post-balance is non-negative and throw an exception if it is negative.
+		if coinBaseCredit.Sign() < 0 {
+			coinbaseBal := st.state.GetBalance(st.evm.Coinbase)
+			postBalance := new(big.Int).Add(coinbaseBal, coinBaseCredit)
+			if postBalance.Sign() < 0 {
+				return nil, 0, vmerr != nil, errInsufficientCoinbaseBalance
+			}
 		}
 		st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), gasPrice))
 
@@ -316,12 +329,15 @@ func (st *StateTransition) refundGasEIP1559() {
 	}
 	st.gas += refund
 
-	// Return ETH for remaining gas, exchanged at the original rate.
+	// tx.origin gets refunded gasprice * (tx.gas - gasused)
+	txGasSubUsed := new(big.Int).Sub(new(big.Int).SetUint64(st.msg.Gas()), new(big.Int).SetUint64(st.gasUsed()))
+
+	// gasPrice = min(BASEFEE + tx.fee_premium, tx.fee_cap)
 	gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
 	if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
 		gasPrice.Set(st.msg.FeeCap())
 	}
-	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), gasPrice)
+	remaining := new(big.Int).Mul(gasPrice, txGasSubUsed)
 	st.state.AddBalance(st.msg.From(), remaining)
 
 	// Also return remaining gas to the block gas counter so it is

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -50,6 +50,7 @@ The state transitioning model does all the necessary work to work out a valid ne
 */
 type StateTransition struct {
 	gp         *GasPool
+	gp1559     *GasPool
 	msg        Message
 	gas        uint64
 	gasPrice   *big.Int
@@ -58,6 +59,7 @@ type StateTransition struct {
 	data       []byte
 	state      vm.StateDB
 	evm        *vm.EVM
+	isEIP1559  bool
 }
 
 // Message represents a message sent to a contract.
@@ -116,15 +118,21 @@ func IntrinsicGas(data []byte, contractCreation, isEIP155 bool, isEIP2028 bool) 
 }
 
 // NewStateTransition initialises and returns a new state transition object.
-func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition {
+func NewStateTransition(evm *vm.EVM, msg Message, gp, gp1559 *GasPool) *StateTransition {
+	isEIP1559 := evm.ChainConfig().IsEIP1559(evm.BlockNumber) && msg.GasPremium() != nil && msg.FeeCap() != nil && evm.BaseFee != nil && gp1559 != nil
+	// check that msg doesn't try to set both legacy and 1559 params
+	// check that legacy has legacy params set
+	// reject 1559 trxs if we are before the 1559 fork blocknumber
 	return &StateTransition{
-		gp:       gp,
-		evm:      evm,
-		msg:      msg,
-		gasPrice: msg.GasPrice(),
-		value:    msg.Value(),
-		data:     msg.Data(),
-		state:    evm.StateDB,
+		gp:        gp,
+		gp1559:    gp1559,
+		evm:       evm,
+		msg:       msg,
+		gasPrice:  msg.GasPrice(),
+		value:     msg.Value(),
+		data:      msg.Data(),
+		state:     evm.StateDB,
+		isEIP1559: isEIP1559,
 	}
 }
 
@@ -135,8 +143,8 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition 
 // the gas used (which includes gas refunds) and an error if it failed. An error always
 // indicates a core error meaning that the message would always fail for that particular
 // state and would never be accepted within a block.
-func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool) ([]byte, uint64, bool, error) {
-	return NewStateTransition(evm, msg, gp).TransitionDb()
+func ApplyMessage(evm *vm.EVM, msg Message, gp, gp1559 *GasPool) ([]byte, uint64, bool, error) {
+	return NewStateTransition(evm, msg, gp, gp1559).TransitionDb()
 }
 
 // to returns the recipient of the message.
@@ -157,6 +165,33 @@ func (st *StateTransition) useGas(amount uint64) error {
 }
 
 func (st *StateTransition) buyGas() error {
+	if st.isEIP1559 {
+		return st.buyGasEIP1559()
+	}
+	return st.buyGasLegacy()
+}
+
+func (st *StateTransition) buyGasEIP1559() error {
+	// any reason we can't set st.gasPrice to this?
+	gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
+	if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
+		gasPrice.Set(st.msg.FeeCap())
+	}
+	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), gasPrice)
+	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
+		return errInsufficientBalanceForGas
+	}
+	if err := st.gp1559.SubGas(st.msg.Gas()); err != nil {
+		return err
+	}
+	st.gas += st.msg.Gas()
+
+	st.initialGas = st.msg.Gas()
+	st.state.SubBalance(st.msg.From(), mgval)
+	return nil
+}
+
+func (st *StateTransition) buyGasLegacy() error {
 	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
 	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
 		return errInsufficientBalanceForGas
@@ -180,6 +215,10 @@ func (st *StateTransition) preCheck() error {
 		} else if nonce > st.msg.Nonce() {
 			return ErrNonceTooLow
 		}
+	}
+	// If we are past the EIP1559 finalization block and this transaction does not conform with EIP1559, throw an error
+	if st.evm.ChainConfig().IsEIP1559Finalized(st.evm.BlockNumber) && !st.isEIP1559 {
+		return ErrTxNotEIP1559
 	}
 	return st.buyGas()
 }
@@ -230,12 +269,29 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
+	if st.isEIP1559 { // if we can set st.gasPrice to the calculated eip1559 gasPrice in buyGas then we don't need this
+		gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
+		if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
+			gasPrice.Set(st.msg.FeeCap())
+		}
+		st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), gasPrice))
+
+		return ret, st.gasUsed(), vmerr != nil, err
+	}
 	st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 
 	return ret, st.gasUsed(), vmerr != nil, err
 }
 
 func (st *StateTransition) refundGas() {
+	if st.isEIP1559 {
+		st.refundGasEIP1559()
+		return
+	}
+	st.refundGasLegacy()
+}
+
+func (st *StateTransition) refundGasLegacy() {
 	// Apply refund counter, capped to half of the used gas.
 	refund := st.gasUsed() / 2
 	if refund > st.state.GetRefund() {
@@ -250,6 +306,27 @@ func (st *StateTransition) refundGas() {
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.
 	st.gp.AddGas(st.gas)
+}
+
+func (st *StateTransition) refundGasEIP1559() {
+	// Apply refund counter, capped to half of the used gas.
+	refund := st.gasUsed() / 2
+	if refund > st.state.GetRefund() {
+		refund = st.state.GetRefund()
+	}
+	st.gas += refund
+
+	// Return ETH for remaining gas, exchanged at the original rate.
+	gasPrice := new(big.Int).Add(st.evm.BaseFee, st.msg.GasPremium())
+	if gasPrice.Cmp(st.msg.FeeCap()) > 0 {
+		gasPrice.Set(st.msg.FeeCap())
+	}
+	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), gasPrice)
+	st.state.AddBalance(st.msg.From(), remaining)
+
+	// Also return remaining gas to the block gas counter so it is
+	// available for the next transaction.
+	st.gp1559.AddGas(st.gas)
 }
 
 // gasUsed returns the amount of gas used up by the state transition.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -76,6 +76,10 @@ var (
 	// than some meaningful limit a user might use. This is not a consensus error
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
+
+	// ErrTxNotEIP1559 is returned if we have passed the EIP1559 finalized block height
+	// and the input transaction does not conform to with EIP1559
+	ErrTxNotEIP1559 = errors.New("transaction does not conform with EIP1559")
 )
 
 var (

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -77,9 +77,24 @@ var (
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
 
-	// ErrTxNotEIP1559 is returned if we have passed the EIP1559 finalized block height
+	// ErrTxNotEIP1559 is returned if we have reached the EIP1559 finalized block height
 	// and the input transaction does not conform to with EIP1559
-	ErrTxNotEIP1559 = errors.New("transaction does not conform with EIP1559")
+	ErrTxNotEIP1559 = fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", params.EIP1559ForkFinalizedBlockNumber)
+
+	// ErrTxIsEIP1559 is returned if we have not reached the EIP1559 initialization block height
+	// and the input transaction is not of the legacy type
+	ErrTxIsEIP1559 = fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", params.EIP1559ForkBlockNumber)
+
+	// ErrTxSetsLegacyAndEIP1559Fields is returned if a transaction attempts to set
+	// both legacy (GasPrice) and EIP1559 (GasPremium and FeeCap) fields
+	ErrTxSetsLegacyAndEIP1559Fields = errors.New("transaction sets both legacy and EIP1559 fields")
+
+	// ErrNoBaseFee is returned if we are past the EIP1559 initialization block but
+	// the current header does not provide a BaseFee
+	ErrNoBaseFee = errors.New("current header does not provide the BaseFee needed to process EIP1559 transactions")
+
+	// ErrMissingGasFields is returned if neither GasPrice nor GasPremium and FeeCap are set
+	ErrMissingGasFields = errors.New("either GasPrice or GasPremium and FeeCap need to be set")
 )
 
 var (
@@ -514,6 +529,33 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
+	// EIP1559 guards
+	if pool.chainconfig.IsEIP1559(pool.chain.CurrentBlock().Number()) && pool.chain.CurrentBlock().BaseFee() == nil {
+		return ErrNoBaseFee
+	}
+	if pool.chainconfig.IsEIP1559Finalized(pool.chain.CurrentBlock().Number()) && (tx.GasPremium() == nil || tx.FeeCap() == nil || tx.GasPrice() != nil) {
+		return ErrTxNotEIP1559
+	}
+	if !pool.chainconfig.IsEIP1559(pool.chain.CurrentBlock().Number()) && (tx.GasPremium() != nil || tx.FeeCap() != nil || tx.GasPrice() == nil) {
+		return ErrTxIsEIP1559
+	}
+	if tx.GasPrice() != nil && (tx.GasPremium() != nil || tx.FeeCap() != nil) {
+		return ErrTxSetsLegacyAndEIP1559Fields
+	}
+	if tx.GasPrice() == nil && (tx.GasPremium() == nil || tx.FeeCap() == nil) {
+		return ErrMissingGasFields
+	}
+	// Set the gasPrice to the tx.GasPrice() if it is non nil (legacy transaction)
+	var gasPrice *big.Int
+	if tx.GasPrice() != nil {
+		gasPrice = tx.GasPrice()
+	} else { // Derive the gasPrice from the tx.GasPremium() and tx.FeeCap() (EIP1559 transaction)
+		gasPrice = new(big.Int).Add(pool.chain.CurrentBlock().BaseFee(), tx.GasPremium())
+		if gasPrice.Cmp(tx.FeeCap()) > 0 {
+			gasPrice.Set(tx.FeeCap())
+		}
+	}
+
 	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
 	if tx.Size() > 32*1024 {
 		return ErrOversizedData
@@ -534,7 +576,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
-	if !local && pool.gasPrice.Cmp(tx.GasPrice()) > 0 {
+	if !local && pool.gasPrice.Cmp(gasPrice) > 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -73,7 +73,7 @@ func transaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) *types.Tr
 }
 
 func pricedTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
-	tx, _ := types.SignTx(types.NewTransaction(nonce, common.Address{}, big.NewInt(100), gaslimit, gasprice, nil), types.HomesteadSigner{}, key)
+	tx, _ := types.SignTx(types.NewTransaction(nonce, common.Address{}, big.NewInt(100), gaslimit, gasprice, nil, nil, nil), types.HomesteadSigner{}, key)
 	return tx
 }
 
@@ -321,7 +321,7 @@ func TestTransactionNegativeValue(t *testing.T) {
 	pool, key := setupTxPool()
 	defer pool.Stop()
 
-	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(-1), 100, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(-1), 100, big.NewInt(1), nil, nil, nil), types.HomesteadSigner{}, key)
 	from, _ := deriveSender(tx)
 	pool.currentState.AddBalance(from, big.NewInt(1))
 	if err := pool.AddRemote(tx); err != ErrNegativeValue {
@@ -375,9 +375,9 @@ func TestTransactionDoubleNonce(t *testing.T) {
 	resetState()
 
 	signer := types.HomesteadSigner{}
-	tx1, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 100000, big.NewInt(1), nil), signer, key)
-	tx2, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 1000000, big.NewInt(2), nil), signer, key)
-	tx3, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 1000000, big.NewInt(1), nil), signer, key)
+	tx1, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 100000, big.NewInt(1), nil, nil, nil), signer, key)
+	tx2, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 1000000, big.NewInt(2), nil, nil, nil), signer, key)
+	tx3, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 1000000, big.NewInt(1), nil, nil, nil), signer, key)
 
 	// Add the first two transaction, ensure higher priced stays only
 	if replace, err := pool.add(tx1, false); err != nil || replace {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -139,7 +139,42 @@ func (h *Header) EncodeRLP(w io.Writer) error {
 		}
 		return rlp.Encode(w, legacyH)
 	}
-	return rlp.Encode(w, h)
+	encHeader := struct {
+		ParentHash  common.Hash
+		UncleHash   common.Hash
+		Coinbase    common.Address
+		Root        common.Hash
+		TxHash      common.Hash
+		ReceiptHash common.Hash
+		Bloom       Bloom
+		Difficulty  *big.Int
+		Number      *big.Int
+		GasLimit    uint64
+		GasUsed     uint64
+		Time        uint64
+		Extra       []byte
+		MixDigest   common.Hash
+		Nonce       BlockNonce
+		BaseFee     *big.Int
+	}{
+		ParentHash:  h.ParentHash,
+		UncleHash:   h.UncleHash,
+		Coinbase:    h.Coinbase,
+		Root:        h.Root,
+		TxHash:      h.TxHash,
+		ReceiptHash: h.ReceiptHash,
+		Bloom:       h.Bloom,
+		Difficulty:  h.Difficulty,
+		Number:      h.Number,
+		GasLimit:    h.GasLimit,
+		GasUsed:     h.GasUsed,
+		Time:        h.Time,
+		Extra:       h.Extra,
+		MixDigest:   h.MixDigest,
+		Nonce:       h.Nonce,
+		BaseFee:     h.BaseFee,
+	}
+	return rlp.Encode(w, encHeader)
 }
 
 func (h *Header) DecodeRLP(s *rlp.Stream) error {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -99,84 +99,48 @@ type headerMarshaling struct {
 	Hash       common.Hash `json:"hash"` // adds call to Hash() in MarshalJSON
 }
 
-// legacyHeader is used to encode headers without the BaseFee field
-type legacyHeader struct {
-	ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
-	UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-	Coinbase    common.Address `json:"miner"            gencodec:"required"`
-	Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
-	TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
-	ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-	Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
-	Difficulty  *big.Int       `json:"difficulty"       gencodec:"required"`
-	Number      *big.Int       `json:"number"           gencodec:"required"`
-	GasLimit    uint64         `json:"gasLimit"         gencodec:"required"`
-	GasUsed     uint64         `json:"gasUsed"          gencodec:"required"`
-	Time        uint64         `json:"timestamp"        gencodec:"required"`
-	Extra       []byte         `json:"extraData"        gencodec:"required"`
-	MixDigest   common.Hash    `json:"mixHash"`
-	Nonce       BlockNonce     `json:"nonce"`
-}
-
+// EncodeRLP implements rlp.Encoder
 func (h *Header) EncodeRLP(w io.Writer) error {
 	if h.BaseFee == nil {
-		legacyH := &legacyHeader{
-			ParentHash:  h.ParentHash,
-			UncleHash:   h.UncleHash,
-			Coinbase:    h.Coinbase,
-			Root:        h.Root,
-			TxHash:      h.TxHash,
-			ReceiptHash: h.ReceiptHash,
-			Bloom:       h.Bloom,
-			Difficulty:  h.Difficulty,
-			Number:      h.Number,
-			GasLimit:    h.GasLimit,
-			GasUsed:     h.GasUsed,
-			Time:        h.Time,
-			Extra:       h.Extra,
-			MixDigest:   h.MixDigest,
-			Nonce:       h.Nonce,
-		}
-		return rlp.Encode(w, legacyH)
+		return rlp.Encode(w, []interface{}{
+			h.ParentHash,
+			h.UncleHash,
+			h.Coinbase,
+			h.Root,
+			h.TxHash,
+			h.ReceiptHash,
+			h.Bloom,
+			h.Difficulty,
+			h.Number,
+			h.GasLimit,
+			h.GasUsed,
+			h.Time,
+			h.Extra,
+			h.MixDigest,
+			h.Nonce,
+		})
 	}
-	encHeader := struct {
-		ParentHash  common.Hash
-		UncleHash   common.Hash
-		Coinbase    common.Address
-		Root        common.Hash
-		TxHash      common.Hash
-		ReceiptHash common.Hash
-		Bloom       Bloom
-		Difficulty  *big.Int
-		Number      *big.Int
-		GasLimit    uint64
-		GasUsed     uint64
-		Time        uint64
-		Extra       []byte
-		MixDigest   common.Hash
-		Nonce       BlockNonce
-		BaseFee     *big.Int
-	}{
-		ParentHash:  h.ParentHash,
-		UncleHash:   h.UncleHash,
-		Coinbase:    h.Coinbase,
-		Root:        h.Root,
-		TxHash:      h.TxHash,
-		ReceiptHash: h.ReceiptHash,
-		Bloom:       h.Bloom,
-		Difficulty:  h.Difficulty,
-		Number:      h.Number,
-		GasLimit:    h.GasLimit,
-		GasUsed:     h.GasUsed,
-		Time:        h.Time,
-		Extra:       h.Extra,
-		MixDigest:   h.MixDigest,
-		Nonce:       h.Nonce,
-		BaseFee:     h.BaseFee,
-	}
-	return rlp.Encode(w, encHeader)
+	return rlp.Encode(w, []interface{}{
+		h.ParentHash,
+		h.UncleHash,
+		h.Coinbase,
+		h.Root,
+		h.TxHash,
+		h.ReceiptHash,
+		h.Bloom,
+		h.Difficulty,
+		h.Number,
+		h.GasLimit,
+		h.GasUsed,
+		h.Time,
+		h.Extra,
+		h.MixDigest,
+		h.Nonce,
+		h.BaseFee,
+	})
 }
 
+// DecodeRLP implements rlp.Decoder
 func (h *Header) DecodeRLP(s *rlp.Stream) error {
 	_, err := s.List()
 	if err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -84,6 +84,7 @@ type Header struct {
 	Extra       []byte         `json:"extraData"        gencodec:"required"`
 	MixDigest   common.Hash    `json:"mixHash"`
 	Nonce       BlockNonce     `json:"nonce"`
+	BaseFee     *big.Int       `json:"baseFee"          rlp:"nil"`
 }
 
 // field type overrides for gencodec
@@ -95,6 +96,164 @@ type headerMarshaling struct {
 	Time       hexutil.Uint64
 	Extra      hexutil.Bytes
 	Hash       common.Hash `json:"hash"` // adds call to Hash() in MarshalJSON
+}
+
+// legacyHeader is used to encode headers without the BaseFee field
+type legacyHeader struct {
+	ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
+	UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+	Coinbase    common.Address `json:"miner"            gencodec:"required"`
+	Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
+	TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+	Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
+	Difficulty  *big.Int       `json:"difficulty"       gencodec:"required"`
+	Number      *big.Int       `json:"number"           gencodec:"required"`
+	GasLimit    uint64         `json:"gasLimit"         gencodec:"required"`
+	GasUsed     uint64         `json:"gasUsed"          gencodec:"required"`
+	Time        uint64         `json:"timestamp"        gencodec:"required"`
+	Extra       []byte         `json:"extraData"        gencodec:"required"`
+	MixDigest   common.Hash    `json:"mixHash"`
+	Nonce       BlockNonce     `json:"nonce"`
+}
+
+func (h *Header) EncodeRLP(w io.Writer) error {
+	if h.BaseFee == nil {
+		legacyH := &legacyHeader{
+			ParentHash:  h.ParentHash,
+			UncleHash:   h.UncleHash,
+			Coinbase:    h.Coinbase,
+			Root:        h.Root,
+			TxHash:      h.TxHash,
+			ReceiptHash: h.ReceiptHash,
+			Bloom:       h.Bloom,
+			Difficulty:  h.Difficulty,
+			Number:      h.Number,
+			GasLimit:    h.GasLimit,
+			GasUsed:     h.GasUsed,
+			Time:        h.Time,
+			Extra:       h.Extra,
+			MixDigest:   h.MixDigest,
+			Nonce:       h.Nonce,
+		}
+		return rlp.Encode(w, legacyH)
+	}
+	return rlp.Encode(w, h)
+}
+
+func (h *Header) DecodeRLP(s *rlp.Stream) error {
+	_, err := s.List()
+	if err != nil {
+		return err
+	}
+	parentHash := new(common.Hash)
+	if err = s.Decode(parentHash); err != nil {
+		return err
+	}
+	uncleHash := new(common.Hash)
+	if err = s.Decode(uncleHash); err != nil {
+		return err
+	}
+	coinbase := new(common.Address)
+	if err = s.Decode(coinbase); err != nil {
+		return err
+	}
+	root := new(common.Hash)
+	if err = s.Decode(root); err != nil {
+		return err
+	}
+	txHash := new(common.Hash)
+	if err = s.Decode(txHash); err != nil {
+		return err
+	}
+	receiptHash := new(common.Hash)
+	if err = s.Decode(receiptHash); err != nil {
+		return err
+	}
+	bloom := new(Bloom)
+	if err = s.Decode(bloom); err != nil {
+		return err
+	}
+	difficulty := new(big.Int)
+	if err = s.Decode(difficulty); err != nil {
+		return err
+	}
+	number := new(big.Int)
+	if err = s.Decode(number); err != nil {
+		return err
+	}
+	gasLimit := new(uint64)
+	if err = s.Decode(gasLimit); err != nil {
+		return err
+	}
+	gasUsed := new(uint64)
+	if err = s.Decode(gasUsed); err != nil {
+		return err
+	}
+	time := new(uint64)
+	if err = s.Decode(time); err != nil {
+		return err
+	}
+	extra := new([]byte)
+	if err = s.Decode(extra); err != nil {
+		return err
+	}
+	mixDigest := new(common.Hash)
+	if err = s.Decode(mixDigest); err != nil {
+		return err
+	}
+	nonce := new(BlockNonce)
+	if err = s.Decode(nonce); err != nil {
+		return err
+	}
+	// if this is the end of the list then we are decoding a legacy header
+	if err = s.ListEnd(); err == nil {
+		h.ParentHash = *parentHash
+		h.UncleHash = *uncleHash
+		h.Coinbase = *coinbase
+		h.Root = *root
+		h.TxHash = *txHash
+		h.ReceiptHash = *receiptHash
+		h.Bloom = *bloom
+		h.Difficulty = difficulty
+		h.Number = number
+		h.GasLimit = *gasLimit
+		h.GasUsed = *gasUsed
+		h.Time = *time
+		h.Extra = *extra
+		h.MixDigest = *mixDigest
+		h.Nonce = *nonce
+		return nil
+	}
+	// if we are not at the end of the list, continue decoding the 1559 header fields
+	if err != rlp.ErrNotAtEOL {
+		return err
+	}
+	baseFee := new(big.Int)
+	if err = s.Decode(baseFee); err != nil {
+		return err
+	}
+	// we should now be at the end of the list even for a 1559 transaction
+	if err = s.ListEnd(); err != nil {
+		return err
+	}
+	h.ParentHash = *parentHash
+	h.UncleHash = *uncleHash
+	h.Coinbase = *coinbase
+	h.Root = *root
+	h.TxHash = *txHash
+	h.ReceiptHash = *receiptHash
+	h.Bloom = *bloom
+	h.Difficulty = difficulty
+	h.Number = number
+	h.GasLimit = *gasLimit
+	h.GasUsed = *gasUsed
+	h.Time = *time
+	h.Extra = *extra
+	h.MixDigest = *mixDigest
+	h.Nonce = *nonce
+	h.BaseFee = baseFee
+	return nil
 }
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -95,6 +95,7 @@ type headerMarshaling struct {
 	GasUsed    hexutil.Uint64
 	Time       hexutil.Uint64
 	Extra      hexutil.Bytes
+	BaseFee    *hexutil.Big
 	Hash       common.Hash `json:"hash"` // adds call to Hash() in MarshalJSON
 }
 
@@ -477,6 +478,7 @@ func (b *Block) TxHash() common.Hash      { return b.header.TxHash }
 func (b *Block) ReceiptHash() common.Hash { return b.header.ReceiptHash }
 func (b *Block) UncleHash() common.Hash   { return b.header.UncleHash }
 func (b *Block) Extra() []byte            { return common.CopyBytes(b.header.Extra) }
+func (b *Block) BaseFee() *big.Int        { return b.header.BaseFee }
 
 func (b *Block) Header() *Header { return CopyHeader(b.header) }
 

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -69,27 +69,6 @@ func TestBlockEncoding(t *testing.T) {
 	}
 }
 
-/*
-type Header struct {
-	ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
-	UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-	Coinbase    common.Address `json:"miner"            gencodec:"required"`
-	Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
-	TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
-	ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-	Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
-	Difficulty  *big.Int       `json:"difficulty"       gencodec:"required"`
-	Number      *big.Int       `json:"number"           gencodec:"required"`
-	GasLimit    uint64         `json:"gasLimit"         gencodec:"required"`
-	GasUsed     uint64         `json:"gasUsed"          gencodec:"required"`
-	Time        uint64         `json:"timestamp"        gencodec:"required"`
-	Extra       []byte         `json:"extraData"        gencodec:"required"`
-	MixDigest   common.Hash    `json:"mixHash"`
-	Nonce       BlockNonce     `json:"nonce"`
-	BaseFee     *big.Int       `json:"baseFee"          rlp:"nil"`
-}
-*/
-
 func TestEIP1559BlockEncoding(t *testing.T) {
 	tx, err := decodeTx(common.Hex2Bytes("f86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ba0612a9c962f0ac2841c671c021e45aeaa23f2892bf34da5d32d7948754cf078bda03a350e0e4e1ff5299228eb921af7c0435dbabd5b3d17f79c925864192ca9d126"))
 	if err != nil {

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -18,6 +18,11 @@ package types
 
 import (
 	"bytes"
+
+	"github.com/ethereum/go-ethereum/params"
+
+	//"fmt"
+	//"github.com/ethereum/go-ethereum/params"
 	"math/big"
 	"reflect"
 	"testing"
@@ -52,6 +57,101 @@ func TestBlockEncoding(t *testing.T) {
 
 	tx1 := NewTransaction(0, common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), big.NewInt(10), 50000, big.NewInt(10), nil, nil, nil)
 	tx1, _ = tx1.WithSignature(HomesteadSigner{}, common.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
+	check("len(Transactions)", len(block.Transactions()), 1)
+	check("Transactions[0].Hash", block.Transactions()[0].Hash(), tx1.Hash())
+
+	ourBlockEnc, err := rlp.EncodeToBytes(&block)
+	if err != nil {
+		t.Fatal("encode error: ", err)
+	}
+	if !bytes.Equal(ourBlockEnc, blockEnc) {
+		t.Errorf("encoded block mismatch:\ngot:  %x\nwant: %x", ourBlockEnc, blockEnc)
+	}
+}
+
+/*
+type Header struct {
+	ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
+	UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+	Coinbase    common.Address `json:"miner"            gencodec:"required"`
+	Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
+	TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+	Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
+	Difficulty  *big.Int       `json:"difficulty"       gencodec:"required"`
+	Number      *big.Int       `json:"number"           gencodec:"required"`
+	GasLimit    uint64         `json:"gasLimit"         gencodec:"required"`
+	GasUsed     uint64         `json:"gasUsed"          gencodec:"required"`
+	Time        uint64         `json:"timestamp"        gencodec:"required"`
+	Extra       []byte         `json:"extraData"        gencodec:"required"`
+	MixDigest   common.Hash    `json:"mixHash"`
+	Nonce       BlockNonce     `json:"nonce"`
+	BaseFee     *big.Int       `json:"baseFee"          rlp:"nil"`
+}
+*/
+
+func TestEIP1559BlockEncoding(t *testing.T) {
+	tx, err := decodeTx(common.Hex2Bytes("f86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ba0612a9c962f0ac2841c671c021e45aeaa23f2892bf34da5d32d7948754cf078bda03a350e0e4e1ff5299228eb921af7c0435dbabd5b3d17f79c925864192ca9d126"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	txs := Transactions{tx}
+	header := &Header{
+		ParentHash: common.HexToHash("0x"),
+		Coinbase:   common.HexToAddress("8888f1f195afa192cfee860698584c030f4c9db1"),
+		Root:       common.HexToHash("ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017"),
+		Difficulty: big.NewInt(131072),
+		Number:     big.NewInt(2675001),
+		GasLimit:   3141592,
+		GasUsed:    21000,
+		Time:       1426516743,
+		MixDigest:  common.HexToHash("bd4472abb6659ebe3ee06ee4d7b72a00a9f4d001caca51342001075469aff498"),
+		Nonce:      EncodeNonce(11617697748499542468),
+		BaseFee:    big.NewInt(800000),
+	}
+	hash := header.Hash()
+	rct := NewReceipt([]byte{0}, false, 800000)
+	rcts := Receipts{rct}
+	rcts.DeriveFields(params.MainnetChainConfig, hash, 2675001, txs)
+	block := NewBlock(header, txs, nil, rcts)
+	blockBytes, err := rlp.EncodeToBytes(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := common.FromHex("f90271f90200a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a0ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017a0ed048395d4a0847b0cecfa3f649a9f4e56fd9813cb1bae507fb8a5a8a45009c6a0e596313d377d2ebcd789a5a17bbd6c6cb458be3f3c896db1e307865aa33acea2b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000830200008328d139832fefd8825208845506eb0780a0bd4472abb6659ebe3ee06ee4d7b72a00a9f4d001caca51342001075469aff49888a13a5a8c8f2bb1c4830c3500f86bf86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ba0612a9c962f0ac2841c671c021e45aeaa23f2892bf34da5d32d7948754cf078bda03a350e0e4e1ff5299228eb921af7c0435dbabd5b3d17f79c925864192ca9d126c0")
+	if !bytes.Equal(blockBytes, expected) {
+		t.Errorf("encoded block mismatch:\ngot:  %x\nwant: %x", blockBytes, expected)
+	}
+}
+
+func TestEIP1559BlockDecoding(t *testing.T) {
+	blockEnc := common.FromHex("f90271f90200a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a0ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017a0ed048395d4a0847b0cecfa3f649a9f4e56fd9813cb1bae507fb8a5a8a45009c6a0e596313d377d2ebcd789a5a17bbd6c6cb458be3f3c896db1e307865aa33acea2b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000830200008328d139832fefd8825208845506eb0780a0bd4472abb6659ebe3ee06ee4d7b72a00a9f4d001caca51342001075469aff49888a13a5a8c8f2bb1c4830c3500f86bf86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ba0612a9c962f0ac2841c671c021e45aeaa23f2892bf34da5d32d7948754cf078bda03a350e0e4e1ff5299228eb921af7c0435dbabd5b3d17f79c925864192ca9d126c0")
+	var block Block
+	if err := rlp.DecodeBytes(blockEnc, &block); err != nil {
+		t.Fatal("decode error: ", err)
+	}
+
+	check := func(f string, got, want interface{}) {
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s mismatch: got %v, want %v", f, got, want)
+		}
+	}
+	check("Difficulty", block.Difficulty(), big.NewInt(131072))
+	check("GasLimit", block.GasLimit(), uint64(3141592))
+	check("GasUsed", block.GasUsed(), uint64(21000))
+	check("Coinbase", block.Coinbase(), common.HexToAddress("8888f1f195afa192cfee860698584c030f4c9db1"))
+	check("MixDigest", block.MixDigest(), common.HexToHash("bd4472abb6659ebe3ee06ee4d7b72a00a9f4d001caca51342001075469aff498"))
+	check("Root", block.Root(), common.HexToHash("ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017"))
+	check("Hash", block.Hash(), common.HexToHash("112545e5bd6c278a01e46061467f23b9e690685d28df917a5ad184171b095770"))
+	check("Nonce", block.Nonce(), uint64(0xa13a5a8c8f2bb1c4))
+	check("Time", block.Time(), uint64(1426516743))
+	check("Size", block.Size(), common.StorageSize(len(blockEnc)))
+	check("BaseFee", block.BaseFee(), big.NewInt(800000))
+
+	tx1, err := decodeTx(common.Hex2Bytes("f86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ba0612a9c962f0ac2841c671c021e45aeaa23f2892bf34da5d32d7948754cf078bda03a350e0e4e1ff5299228eb921af7c0435dbabd5b3d17f79c925864192ca9d126"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	check("len(Transactions)", len(block.Transactions()), 1)
 	check("Transactions[0].Hash", block.Transactions()[0].Hash(), tx1.Hash())
 

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -50,7 +50,7 @@ func TestBlockEncoding(t *testing.T) {
 	check("Time", block.Time(), uint64(1426516743))
 	check("Size", block.Size(), common.StorageSize(len(blockEnc)))
 
-	tx1 := NewTransaction(0, common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), big.NewInt(10), 50000, big.NewInt(10), nil)
+	tx1 := NewTransaction(0, common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), big.NewInt(10), 50000, big.NewInt(10), nil, nil, nil)
 	tx1, _ = tx1.WithSignature(HomesteadSigner{}, common.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
 	check("len(Transactions)", len(block.Transactions()), 1)
 	check("Transactions[0].Hash", block.Transactions()[0].Hash(), tx1.Hash())

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -31,6 +31,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   common.Hash    `json:"mixHash"`
 		Nonce       BlockNonce     `json:"nonce"`
+		BaseFee     *hexutil.Big   `json:"baseFee"          rlp:"nil"`
 		Hash        common.Hash    `json:"hash"`
 	}
 	var enc Header
@@ -49,6 +50,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.Extra = h.Extra
 	enc.MixDigest = h.MixDigest
 	enc.Nonce = h.Nonce
+	enc.BaseFee = (*hexutil.Big)(h.BaseFee)
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -71,6 +73,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		Extra       *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   *common.Hash    `json:"mixHash"`
 		Nonce       *BlockNonce     `json:"nonce"`
+		BaseFee     *hexutil.Big    `json:"baseFee"          rlp:"nil"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -133,6 +136,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Nonce != nil {
 		h.Nonce = *dec.Nonce
+	}
+	if dec.BaseFee != nil {
+		h.BaseFee = (*big.Int)(dec.BaseFee)
 	}
 	return nil
 }

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -22,6 +22,8 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload      hexutil.Bytes   `json:"input"    gencodec:"required"`
+		GasPremium   *hexutil.Big    `json:"gasPremium" rlp:"nil"`
+		FeeCap       *hexutil.Big    `json:"feeCap"     rlp:"nil"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
@@ -34,6 +36,8 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	enc.Recipient = t.Recipient
 	enc.Amount = (*hexutil.Big)(t.Amount)
 	enc.Payload = t.Payload
+	enc.GasPremium = (*hexutil.Big)(t.GasPremium)
+	enc.FeeCap = (*hexutil.Big)(t.FeeCap)
 	enc.V = (*hexutil.Big)(t.V)
 	enc.R = (*hexutil.Big)(t.R)
 	enc.S = (*hexutil.Big)(t.S)
@@ -50,6 +54,8 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload      *hexutil.Bytes  `json:"input"    gencodec:"required"`
+		GasPremium   *hexutil.Big    `json:"gasPremium" rlp:"nil"`
+		FeeCap       *hexutil.Big    `json:"feeCap"     rlp:"nil"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
@@ -82,6 +88,12 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'input' for txdata")
 	}
 	t.Payload = *dec.Payload
+	if dec.GasPremium != nil {
+		t.GasPremium = (*big.Int)(dec.GasPremium)
+	}
+	if dec.FeeCap != nil {
+		t.FeeCap = (*big.Int)(dec.FeeCap)
+	}
 	if dec.V == nil {
 		return errors.New("missing required field 'v' for txdata")
 	}

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -48,7 +48,7 @@ func TestLegacyReceiptDecoding(t *testing.T) {
 		},
 	}
 
-	tx := NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil)
+	tx := NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil, nil, nil)
 	receipt := &Receipt{
 		Status:            ReceiptStatusFailed,
 		CumulativeGasUsed: 1,
@@ -155,8 +155,8 @@ func encodeAsV3StoredReceiptRLP(want *Receipt) ([]byte, error) {
 func TestDeriveFields(t *testing.T) {
 	// Create a few transactions to have receipts for
 	txs := Transactions{
-		NewContractCreation(1, big.NewInt(1), 1, big.NewInt(1), nil),
-		NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil),
+		NewContractCreation(1, big.NewInt(1), 1, big.NewInt(1), nil, nil, nil),
+		NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil, nil, nil),
 	}
 	// Create the corresponding receipts
 	receipts := Receipts{

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -349,6 +349,8 @@ func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 		amount:     tx.data.Amount,
 		data:       tx.data.Payload,
 		checkNonce: true,
+		gasPremium: tx.data.GasPremium,
+		feeCap:     tx.data.FeeCap,
 	}
 
 	var err error
@@ -517,9 +519,11 @@ type Message struct {
 	gasPrice   *big.Int
 	data       []byte
 	checkNonce bool
+	gasPremium *big.Int
+	feeCap     *big.Int
 }
 
-func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, checkNonce bool) Message {
+func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, checkNonce bool, gasPremium, feeCap *big.Int) Message {
 	return Message{
 		from:       from,
 		to:         to,
@@ -529,6 +533,8 @@ func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *b
 		gasPrice:   gasPrice,
 		data:       data,
 		checkNonce: checkNonce,
+		gasPremium: gasPremium,
+		feeCap:     feeCap,
 	}
 }
 
@@ -540,3 +546,5 @@ func (m Message) Gas() uint64          { return m.gasLimit }
 func (m Message) Nonce() uint64        { return m.nonce }
 func (m Message) Data() []byte         { return m.data }
 func (m Message) CheckNonce() bool     { return m.checkNonce }
+func (m Message) GasPremium() *big.Int { return m.gasPremium }
+func (m Message) FeeCap() *big.Int     { return m.feeCap }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -135,36 +135,20 @@ func isProtectedV(V *big.Int) bool {
 	return true
 }
 
-// legacyTxData is used to RLP encode txData if either the gasPremium or the feeCap fields are nil
-type legacyTxData struct {
-	AccountNonce uint64          `json:"nonce"    gencodec:"required"`
-	Price        *big.Int        `json:"gasPrice" gencodec:"required"`
-	GasLimit     uint64          `json:"gas"      gencodec:"required"`
-	Recipient    *common.Address `json:"to"       rlp:"nil"` // nil means contract creation
-	Amount       *big.Int        `json:"value"    gencodec:"required"`
-	Payload      []byte          `json:"input"    gencodec:"required"`
-
-	// Signature values
-	V *big.Int `json:"v" gencodec:"required"`
-	R *big.Int `json:"r" gencodec:"required"`
-	S *big.Int `json:"s" gencodec:"required"`
-}
-
 // EncodeRLP implements rlp.Encoder
 func (tx *Transaction) EncodeRLP(w io.Writer) error {
 	if tx.data.FeeCap == nil || tx.data.GasPremium == nil {
-		legacyTx := &legacyTxData{
-			AccountNonce: tx.data.AccountNonce,
-			Price:        tx.data.Price,
-			GasLimit:     tx.data.GasLimit,
-			Recipient:    tx.data.Recipient,
-			Amount:       tx.data.Amount,
-			Payload:      tx.data.Payload,
-			V:            tx.data.V,
-			R:            tx.data.R,
-			S:            tx.data.S,
-		}
-		return rlp.Encode(w, legacyTx)
+		return rlp.Encode(w, []interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+			tx.data.V,
+			tx.data.R,
+			tx.data.S,
+		})
 	}
 	return rlp.Encode(w, &tx.data)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -52,8 +52,8 @@ type txdata struct {
 	Payload      []byte          `json:"input"    gencodec:"required"`
 
 	// EIP1559 gas values
-	GasPremium *big.Int `json:"gasPremium" gencodec:"required" rlp:"nil"` // nil means legacy transaction
-	FeeCap     *big.Int `json:"feeCap"     gencodec:"required" rlp:"nil"` // nil means legacy transaction
+	GasPremium *big.Int `json:"gasPremium" rlp:"nil"` // nil means legacy transaction
+	FeeCap     *big.Int `json:"feeCap"     rlp:"nil"` // nil means legacy transaction
 
 	// Signature values
 	V *big.Int `json:"v" gencodec:"required"`
@@ -133,12 +133,7 @@ func isProtectedV(V *big.Int) bool {
 	return true
 }
 
-/*
-EncodeRLP should be modified to encode a struct without the gasPremium and feeCap fields if either are nil, or the raw txdata struct if not.
-This keeps the RLP encoding of legacy transactions identical to the way they were pre-fork.
-*/
-
-// legacyTxData is used to RLP decode and encode txData if either the gasPremium or the feeCap fields are nil
+// legacyTxData is used to RLP encode txData if either the gasPremium or the feeCap fields are nil
 type legacyTxData struct {
 	AccountNonce uint64          `json:"nonce"    gencodec:"required"`
 	Price        *big.Int        `json:"gasPrice" gencodec:"required"`
@@ -172,28 +167,22 @@ func (tx *Transaction) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &tx.data)
 }
 
-/*
-DecodeRLP should decode the rlp.Stream value into individual fields first, then build the resulting struct.
-If decoding the gasPremium’s value returns an EOL error, then this is a legacy transaction.
-This allows legacy RLP-encoded transactions to be decoded while properly handling errors
-*/
-
 // DecodeRLP implements rlp.Decoder
 func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 	size, err := stream.List()
 	if err != nil {
 		return err
 	}
-	var accountNonce uint64
-	if err = stream.Decode(&accountNonce); err != nil {
+	accountNonce := new(uint64)
+	if err = stream.Decode(accountNonce); err != nil {
 		return err
 	}
 	price := new(big.Int)
 	if err = stream.Decode(price); err != nil {
 		return err
 	}
-	var gasLimit uint64
-	if err = stream.Decode(&gasLimit); err != nil {
+	gasLimit := new(uint64)
+	if err = stream.Decode(gasLimit); err != nil {
 		return err
 	}
 	_, recipientSize, err := stream.Kind()
@@ -201,8 +190,8 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 		return err
 	}
 	var recipient *common.Address
+	// the below is to handle the "rlp: nil" tag (tag itself is not needed anymore because of this manual handling)
 	// attempting to unpack a zero value into *common.Address throws an error
-	// if the value is of size zero we leave the recipient "nil"
 	// if there is a non-zero address, unpack it
 	if recipientSize != 0 {
 		recipient = new(common.Address)
@@ -210,7 +199,7 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 			return err
 		}
 	} else {
-		// otherwise throw away the zero value, move to next position in the list, and leave recipient nil
+		// otherwise if the value is of size zero throw away the value, move to next value in the stream, and leave recipient nil
 		if _, err = stream.Raw(); err != nil {
 			return err
 		}
@@ -219,8 +208,8 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 	if err = stream.Decode(amount); err != nil {
 		return err
 	}
-	var payload []byte
-	if err = stream.Decode(&payload); err != nil {
+	payload := new([]byte)
+	if err = stream.Decode(payload); err != nil {
 		return err
 	}
 	gasPremium := new(big.Int)
@@ -235,17 +224,16 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 	if err = stream.Decode(v); err != nil {
 		return err
 	}
-
 	// if this is the end of the list then we are decoding a legacy transaction
-	// so the last decoded gasPremium, feeCap, and v values are shifted into the v, r, and s values
+	// so the decoded gasPremium, feeCap, and v values are shifted into the v, r, and s values
 	if err = stream.ListEnd(); err == nil {
 		tx.data = txdata{
-			AccountNonce: accountNonce,
+			AccountNonce: *accountNonce,
 			Price:        price,
-			GasLimit:     gasLimit,
+			GasLimit:     *gasLimit,
 			Recipient:    recipient,
 			Amount:       amount,
-			Payload:      payload,
+			Payload:      *payload,
 			V:            gasPremium,
 			R:            feeCap,
 			S:            v,
@@ -253,6 +241,7 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 		tx.size.Store(common.StorageSize(rlp.ListSize(size)))
 		return nil
 	}
+	// if we are not at the end of the list, continue decoding the 1559 transaction fields
 	if err != rlp.ErrNotAtEOL {
 		return err
 	}
@@ -264,13 +253,17 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 	if err := stream.Decode(s); err != nil {
 		return err
 	}
+	// we should now be at the end of the list for a EIP1559 transaction
+	if err = stream.ListEnd(); err != nil {
+		return err
+	}
 	tx.data = txdata{
-		AccountNonce: accountNonce,
+		AccountNonce: *accountNonce,
 		Price:        price,
-		GasLimit:     gasLimit,
+		GasLimit:     *gasLimit,
 		Recipient:    recipient,
 		Amount:       amount,
-		Payload:      payload,
+		Payload:      *payload,
 		GasPremium:   gasPremium,
 		FeeCap:       feeCap,
 		V:            v,

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -70,6 +70,8 @@ type txdataMarshaling struct {
 	GasLimit     hexutil.Uint64
 	Amount       *hexutil.Big
 	Payload      hexutil.Bytes
+	GasPremium   *hexutil.Big
+	FeeCap       *hexutil.Big
 	V            *hexutil.Big
 	R            *hexutil.Big
 	S            *hexutil.Big

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -51,6 +51,10 @@ type txdata struct {
 	Amount       *big.Int        `json:"value"    gencodec:"required"`
 	Payload      []byte          `json:"input"    gencodec:"required"`
 
+	// EIP1559 gas values
+	GasPremium *big.Int `json:"gasPremium" gencodec:"required" rlp:"nil"` // nil means legacy transaction
+	FeeCap     *big.Int `json:"feeCap"     gencodec:"required" rlp:"nil"` // nil means legacy transaction
+
 	// Signature values
 	V *big.Int `json:"v" gencodec:"required"`
 	R *big.Int `json:"r" gencodec:"required"`
@@ -71,15 +75,15 @@ type txdataMarshaling struct {
 	S            *hexutil.Big
 }
 
-func NewTransaction(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {
-	return newTransaction(nonce, &to, amount, gasLimit, gasPrice, data)
+func NewTransaction(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, gasPremium, feeCap *big.Int) *Transaction {
+	return newTransaction(nonce, &to, amount, gasLimit, gasPrice, data, gasPremium, feeCap)
 }
 
-func NewContractCreation(nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {
-	return newTransaction(nonce, nil, amount, gasLimit, gasPrice, data)
+func NewContractCreation(nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, gasPremium, feeCap *big.Int) *Transaction {
+	return newTransaction(nonce, nil, amount, gasLimit, gasPrice, data, gasPremium, feeCap)
 }
 
-func newTransaction(nonce uint64, to *common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {
+func newTransaction(nonce uint64, to *common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, gasPremium, feeCap *big.Int) *Transaction {
 	if len(data) > 0 {
 		data = common.CopyBytes(data)
 	}
@@ -99,6 +103,12 @@ func newTransaction(nonce uint64, to *common.Address, amount *big.Int, gasLimit 
 	}
 	if gasPrice != nil {
 		d.Price.Set(gasPrice)
+	}
+	if gasPremium != nil {
+		d.GasPremium = gasPremium
+	}
+	if feeCap != nil {
+		d.FeeCap = feeCap
 	}
 
 	return &Transaction{data: d}
@@ -123,20 +133,152 @@ func isProtectedV(V *big.Int) bool {
 	return true
 }
 
+/*
+EncodeRLP should be modified to encode a struct without the gasPremium and feeCap fields if either are nil, or the raw txdata struct if not.
+This keeps the RLP encoding of legacy transactions identical to the way they were pre-fork.
+*/
+
+// legacyTxData is used to RLP decode and encode txData if either the gasPremium or the feeCap fields are nil
+type legacyTxData struct {
+	AccountNonce uint64          `json:"nonce"    gencodec:"required"`
+	Price        *big.Int        `json:"gasPrice" gencodec:"required"`
+	GasLimit     uint64          `json:"gas"      gencodec:"required"`
+	Recipient    *common.Address `json:"to"       rlp:"nil"` // nil means contract creation
+	Amount       *big.Int        `json:"value"    gencodec:"required"`
+	Payload      []byte          `json:"input"    gencodec:"required"`
+
+	// Signature values
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
+}
+
 // EncodeRLP implements rlp.Encoder
 func (tx *Transaction) EncodeRLP(w io.Writer) error {
+	if tx.data.FeeCap == nil || tx.data.GasPremium == nil {
+		legacyTx := &legacyTxData{
+			AccountNonce: tx.data.AccountNonce,
+			Price:        tx.data.Price,
+			GasLimit:     tx.data.GasLimit,
+			Recipient:    tx.data.Recipient,
+			Amount:       tx.data.Amount,
+			Payload:      tx.data.Payload,
+			V:            tx.data.V,
+			R:            tx.data.R,
+			S:            tx.data.S,
+		}
+		return rlp.Encode(w, legacyTx)
+	}
 	return rlp.Encode(w, &tx.data)
 }
 
+/*
+DecodeRLP should decode the rlp.Stream value into individual fields first, then build the resulting struct.
+If decoding the gasPremium’s value returns an EOL error, then this is a legacy transaction.
+This allows legacy RLP-encoded transactions to be decoded while properly handling errors
+*/
+
 // DecodeRLP implements rlp.Decoder
-func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
-	_, size, _ := s.Kind()
-	err := s.Decode(&tx.data)
-	if err == nil {
-		tx.size.Store(common.StorageSize(rlp.ListSize(size)))
+func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
+	size, err := stream.List()
+	if err != nil {
+		return err
+	}
+	var accountNonce uint64
+	if err = stream.Decode(&accountNonce); err != nil {
+		return err
+	}
+	price := new(big.Int)
+	if err = stream.Decode(price); err != nil {
+		return err
+	}
+	var gasLimit uint64
+	if err = stream.Decode(&gasLimit); err != nil {
+		return err
+	}
+	_, recipientSize, err := stream.Kind()
+	if err != nil {
+		return err
+	}
+	var recipient *common.Address
+	// attempting to unpack a zero value into *common.Address throws an error
+	// if the value is of size zero we leave the recipient "nil"
+	// if there is a non-zero address, unpack it
+	if recipientSize != 0 {
+		recipient = new(common.Address)
+		if err = stream.Decode(recipient); err != nil {
+			return err
+		}
+	} else {
+		// otherwise throw away the zero value, move to next position in the list, and leave recipient nil
+		if _, err = stream.Raw(); err != nil {
+			return err
+		}
+	}
+	amount := new(big.Int)
+	if err = stream.Decode(amount); err != nil {
+		return err
+	}
+	var payload []byte
+	if err = stream.Decode(&payload); err != nil {
+		return err
+	}
+	gasPremium := new(big.Int)
+	if err = stream.Decode(gasPremium); err != nil {
+		return err
+	}
+	feeCap := new(big.Int)
+	if err = stream.Decode(feeCap); err != nil {
+		return err
+	}
+	v := new(big.Int)
+	if err = stream.Decode(v); err != nil {
+		return err
 	}
 
-	return err
+	// if this is the end of the list then we are decoding a legacy transaction
+	// so the last decoded gasPremium, feeCap, and v values are shifted into the v, r, and s values
+	if err = stream.ListEnd(); err == nil {
+		tx.data = txdata{
+			AccountNonce: accountNonce,
+			Price:        price,
+			GasLimit:     gasLimit,
+			Recipient:    recipient,
+			Amount:       amount,
+			Payload:      payload,
+			V:            gasPremium,
+			R:            feeCap,
+			S:            v,
+		}
+		tx.size.Store(common.StorageSize(rlp.ListSize(size)))
+		return nil
+	}
+	if err != rlp.ErrNotAtEOL {
+		return err
+	}
+	r := new(big.Int)
+	if err := stream.Decode(r); err != nil {
+		return err
+	}
+	s := new(big.Int)
+	if err := stream.Decode(s); err != nil {
+		return err
+	}
+	tx.data = txdata{
+		AccountNonce: accountNonce,
+		Price:        price,
+		GasLimit:     gasLimit,
+		Recipient:    recipient,
+		Amount:       amount,
+		Payload:      payload,
+		GasPremium:   gasPremium,
+		FeeCap:       feeCap,
+		V:            v,
+		R:            r,
+		S:            v,
+	}
+	tx.size.Store(common.StorageSize(rlp.ListSize(size)))
+	return nil
 }
 
 // MarshalJSON encodes the web3 RPC transaction format.
@@ -172,12 +314,14 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
-func (tx *Transaction) Gas() uint64        { return tx.data.GasLimit }
-func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }
-func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amount) }
-func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
-func (tx *Transaction) CheckNonce() bool   { return true }
+func (tx *Transaction) Data() []byte         { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) Gas() uint64          { return tx.data.GasLimit }
+func (tx *Transaction) GasPrice() *big.Int   { return new(big.Int).Set(tx.data.Price) }
+func (tx *Transaction) Value() *big.Int      { return new(big.Int).Set(tx.data.Amount) }
+func (tx *Transaction) Nonce() uint64        { return tx.data.AccountNonce }
+func (tx *Transaction) CheckNonce() bool     { return true }
+func (tx *Transaction) GasPremium() *big.Int { return tx.data.GasPremium }
+func (tx *Transaction) FeeCap() *big.Int     { return tx.data.FeeCap }
 
 // To returns the recipient address of the transaction.
 // It returns nil if the transaction is a contract creation.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -523,6 +523,7 @@ type Message struct {
 	feeCap     *big.Int
 }
 
+// NewMessage creates and returns a new message
 func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, checkNonce bool, gasPremium, feeCap *big.Int) Message {
 	return Message{
 		from:       from,

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -270,7 +270,7 @@ func (tx *Transaction) DecodeRLP(stream *rlp.Stream) error {
 		FeeCap:       feeCap,
 		V:            v,
 		R:            r,
-		S:            v,
+		S:            s,
 	}
 	tx.size.Store(common.StorageSize(rlp.ListSize(size)))
 	return nil

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -153,6 +153,17 @@ func (s EIP155Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s EIP155Signer) Hash(tx *Transaction) common.Hash {
+	if tx.data.GasPremium == nil && tx.data.FeeCap == nil {
+		return rlpHash([]interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+			s.chainId, uint(0), uint(0),
+		})
+	}
 	return rlpHash([]interface{}{
 		tx.data.AccountNonce,
 		tx.data.Price,
@@ -160,6 +171,8 @@ func (s EIP155Signer) Hash(tx *Transaction) common.Hash {
 		tx.data.Recipient,
 		tx.data.Amount,
 		tx.data.Payload,
+		tx.data.GasPremium,
+		tx.data.FeeCap,
 		s.chainId, uint(0), uint(0),
 	})
 }
@@ -205,6 +218,16 @@ func (fs FrontierSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v *
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
+	if tx.data.GasPremium == nil && tx.data.FeeCap == nil {
+		return rlpHash([]interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+		})
+	}
 	return rlpHash([]interface{}{
 		tx.data.AccountNonce,
 		tx.data.Price,
@@ -212,6 +235,8 @@ func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
 		tx.data.Recipient,
 		tx.data.Amount,
 		tx.data.Payload,
+		tx.data.GasPremium,
+		tx.data.FeeCap,
 	})
 }
 

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -30,7 +30,7 @@ func TestEIP155Signing(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
 	signer := NewEIP155Signer(big.NewInt(18))
-	tx, err := SignTx(NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil), signer, key)
+	tx, err := SignTx(NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil, nil, nil), signer, key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestEIP155ChainId(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
 	signer := NewEIP155Signer(big.NewInt(18))
-	tx, err := SignTx(NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil), signer, key)
+	tx, err := SignTx(NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil, nil, nil), signer, key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestEIP155ChainId(t *testing.T) {
 		t.Error("expected chainId to be", signer.chainId, "got", tx.ChainId())
 	}
 
-	tx = NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil)
+	tx = NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil, nil, nil)
 	tx, err = SignTx(tx, HomesteadSigner{}, key)
 	if err != nil {
 		t.Fatal(err)
@@ -118,7 +118,7 @@ func TestEIP155SigningVitalik(t *testing.T) {
 func TestChainId(t *testing.T) {
 	key, _ := defaultTestKey()
 
-	tx := NewTransaction(0, common.Address{}, new(big.Int), 0, new(big.Int), nil)
+	tx := NewTransaction(0, common.Address{}, new(big.Int), 0, new(big.Int), nil, nil, nil)
 
 	var err error
 	tx, err = SignTx(tx, NewEIP155Signer(big.NewInt(1)), key)

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -36,6 +36,8 @@ var (
 		common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
 		big.NewInt(0), 0, big.NewInt(0),
 		nil,
+		nil,
+		nil,
 	)
 
 	rightvrsTx, _ = NewTransaction(
@@ -45,6 +47,8 @@ var (
 		2000,
 		big.NewInt(1),
 		common.FromHex("5544"),
+		nil,
+		nil,
 	).WithSignature(
 		HomesteadSigner{},
 		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"),
@@ -134,7 +138,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		for i := 0; i < 25; i++ {
-			tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
+			tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil, nil, nil), signer, key)
 			groups[addr] = append(groups[addr], tx)
 		}
 	}
@@ -185,9 +189,9 @@ func TestTransactionJSON(t *testing.T) {
 		var tx *Transaction
 		switch i % 2 {
 		case 0:
-			tx = NewTransaction(i, common.Address{1}, common.Big0, 1, common.Big2, []byte("abcdef"))
+			tx = NewTransaction(i, common.Address{1}, common.Big0, 1, common.Big2, []byte("abcdef"), nil, nil)
 		case 1:
-			tx = NewContractCreation(i, common.Big0, 1, common.Big2, []byte("abcdef"))
+			tx = NewContractCreation(i, common.Big0, 1, common.Big2, []byte("abcdef"), nil, nil)
 		}
 		transactions = append(transactions, tx)
 

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/json"
+	"log"
 	"math/big"
 	"testing"
 
@@ -53,15 +54,74 @@ var (
 		HomesteadSigner{},
 		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"),
 	)
+
+	noRctNoSigTx = NewContractCreation(
+		3,
+		big.NewInt(10),
+		2000,
+		big.NewInt(1),
+		common.FromHex("5544"),
+		nil,
+		nil,
+	)
+
+	noSignatureTx = NewTransaction(
+		3,
+		common.HexToAddress("b94f5374fce5edbc8e2a8697c15331677e6ebf0b"),
+		big.NewInt(10),
+		2000,
+		big.NewInt(1),
+		common.FromHex("5544"),
+		nil,
+		nil,
+	)
+
+	eip1559Tx, _ = NewTransaction(
+		3,
+		common.HexToAddress("b94f5374fce5edbc8e2a8697c15331677e6ebf0b"),
+		big.NewInt(10),
+		2000,
+		nil,
+		common.FromHex("5544"),
+		big.NewInt(200000),
+		big.NewInt(800000),
+	).WithSignature(
+		HomesteadSigner{},
+		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"),
+	)
+
+	eip1559NoRctNoSigTx = NewContractCreation(
+		3,
+		big.NewInt(10),
+		2000,
+		nil,
+		common.FromHex("5544"),
+		big.NewInt(200000),
+		big.NewInt(800000),
+	)
+
+	eip1559NoSignatureTx = NewTransaction(
+		3,
+		common.HexToAddress("b94f5374fce5edbc8e2a8697c15331677e6ebf0b"),
+		big.NewInt(10),
+		2000,
+		nil,
+		common.FromHex("5544"),
+		big.NewInt(200000),
+		big.NewInt(800000),
+	)
 )
 
 func TestTransactionSigHash(t *testing.T) {
 	var homestead HomesteadSigner
 	if homestead.Hash(emptyTx) != common.HexToHash("c775b99e7ad12f50d819fcd602390467e28141316969f4b57f0626f74fe3b386") {
-		t.Errorf("empty transaction hash mismatch, got %x", emptyTx.Hash())
+		t.Errorf("empty transaction hash mismatch, got %x", homestead.Hash(emptyTx))
 	}
 	if homestead.Hash(rightvrsTx) != common.HexToHash("fe7a79529ed5f7c3375d06b26b186a8644e0e16c373d7a12be41c62d6042b77a") {
-		t.Errorf("RightVRS transaction hash mismatch, got %x", rightvrsTx.Hash())
+		t.Errorf("RightVRS transaction hash mismatch, got %x", homestead.Hash(rightvrsTx))
+	}
+	if homestead.Hash(eip1559Tx) != common.HexToHash("33bf0422a1819f7b82ae6cba37ae0169a37ec05ccb6d5a9963fe48cf765fe97f") {
+		t.Errorf("eip1559Tx transaction hash mismatch, got %x", homestead.Hash(eip1559Tx))
 	}
 }
 
@@ -73,6 +133,17 @@ func TestTransactionEncode(t *testing.T) {
 	should := common.FromHex("f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3")
 	if !bytes.Equal(txb, should) {
 		t.Errorf("encoded RLP mismatch, got %x", txb)
+	}
+}
+
+func TestEIP1159TransactionEncode(t *testing.T) {
+	tx1559b, err := rlp.EncodeToBytes(eip1559Tx)
+	if err != nil {
+		t.Fatalf("EIP1559 tx encode error: %v", err)
+	}
+	tx1559bshould := common.FromHex("f86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3")
+	if !bytes.Equal(tx1559b, tx1559bshould) {
+		t.Errorf("EIP1559 tx encoded RLP mismatch, got %x", tx1559b)
 	}
 }
 
@@ -90,12 +161,11 @@ func defaultTestKey() (*ecdsa.PrivateKey, common.Address) {
 }
 
 func TestRecipientEmpty(t *testing.T) {
-	_, addr := defaultTestKey()
+	key, addr := defaultTestKey()
 	tx, err := decodeTx(common.Hex2Bytes("f8498080808080011ca09b16de9d5bdee2cf56c28d16275a4da68cd30273e2525f3959f5d62557489921a0372ebd8fb3345f7db7b5a86d42e24d36e983e259b0664ceb8c227ec9af572f3d"))
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	from, err := Sender(HomesteadSigner{}, tx)
 	if err != nil {
 		t.Fatal(err)
@@ -103,21 +173,100 @@ func TestRecipientEmpty(t *testing.T) {
 	if addr != from {
 		t.Fatal("derived address doesn't match")
 	}
-}
 
-func TestRecipientNormal(t *testing.T) {
-	_, addr := defaultTestKey()
-
-	tx, err := decodeTx(common.Hex2Bytes("f85d80808094000000000000000000000000000000000000000080011ca0527c0d8f5c63f7b9f41324a7c8a563ee1190bcbf0dac8ab446291bdbf32f5c79a0552c4ef0a09a04395074dab9ed34d3fbfb843c2f2546cc30fe89ec143ca94ca6"))
+	tx2, err := SignTx(noRctNoSigTx, HomesteadSigner{}, key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	from2, err := Sender(HomesteadSigner{}, tx2)
 	if err != nil {
 		t.Fatal(err)
 	}
+	if addr != from2 {
+		t.Fatal("derived address doesn't match")
+	}
+}
 
+func TestEIP1559RecipientEmpty(t *testing.T) {
+	key, addr := defaultTestKey()
+
+	tx, err := decodeTx(common.Hex2Bytes("f85503808207d0800a82554483030d40830c35001ca09de1afa53c1d66d6d759d28c1f2f48e3073de340e0b0966bd3b72e86c61dc40ca0120a40bca942f11fc1c00ac52f499acb006dd7cb70e3dbf41bae82e4fbf373c3"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	from, err := Sender(HomesteadSigner{}, tx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if addr != from {
+		t.Fatal("derived address doesn't match")
+	}
+
+	tx2, err := SignTx(eip1559NoRctNoSigTx, HomesteadSigner{}, key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	from2, err := Sender(HomesteadSigner{}, tx2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != from2 {
+		t.Fatal("derived address doesn't match")
+	}
+}
+
+func TestRecipientNormal(t *testing.T) {
+	key, addr := defaultTestKey()
+
+	tx, err := decodeTx(common.Hex2Bytes("f85d80808094000000000000000000000000000000000000000080011ca0527c0d8f5c63f7b9f41324a7c8a563ee1190bcbf0dac8ab446291bdbf32f5c79a0552c4ef0a09a04395074dab9ed34d3fbfb843c2f2546cc30fe89ec143ca94ca6"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	from, err := Sender(HomesteadSigner{}, tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != from {
+		t.Fatal("derived address doesn't match")
+	}
+
+	tx2, err := SignTx(noSignatureTx, HomesteadSigner{}, key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	from2, err := Sender(HomesteadSigner{}, tx2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != from2 {
+		t.Fatal("derived address doesn't match")
+	}
+}
+
+func TestEIP1559RecipientNormal(t *testing.T) {
+	key, addr := defaultTestKey()
+
+	tx, err := decodeTx(common.Hex2Bytes("f86903808207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a82554483030d40830c35001ba0612a9c962f0ac2841c671c021e45aeaa23f2892bf34da5d32d7948754cf078bda03a350e0e4e1ff5299228eb921af7c0435dbabd5b3d17f79c925864192ca9d126"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	from, err := Sender(HomesteadSigner{}, tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != from {
+		t.Fatal("derived address doesn't match")
+	}
+
+	tx2, err := SignTx(eip1559NoSignatureTx, HomesteadSigner{}, key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	from2, err := Sender(HomesteadSigner{}, tx2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != from2 {
 		t.Fatal("derived address doesn't match")
 	}
 }
@@ -192,6 +341,54 @@ func TestTransactionJSON(t *testing.T) {
 			tx = NewTransaction(i, common.Address{1}, common.Big0, 1, common.Big2, []byte("abcdef"), nil, nil)
 		case 1:
 			tx = NewContractCreation(i, common.Big0, 1, common.Big2, []byte("abcdef"), nil, nil)
+		}
+		transactions = append(transactions, tx)
+
+		signedTx, err := SignTx(tx, signer, key)
+		if err != nil {
+			t.Fatalf("could not sign transaction: %v", err)
+		}
+
+		transactions = append(transactions, signedTx)
+	}
+
+	for _, tx := range transactions {
+		data, err := json.Marshal(tx)
+		if err != nil {
+			t.Fatalf("json.Marshal failed: %v", err)
+		}
+
+		var parsedTx *Transaction
+		if err := json.Unmarshal(data, &parsedTx); err != nil {
+			t.Fatalf("json.Unmarshal failed: %v", err)
+		}
+
+		// compare nonce, price, gaslimit, recipient, amount, payload, V, R, S
+		if tx.Hash() != parsedTx.Hash() {
+			t.Errorf("parsed tx differs from original tx, want %v, got %v", tx, parsedTx)
+		}
+		if tx.ChainId().Cmp(parsedTx.ChainId()) != 0 {
+			t.Errorf("invalid chain id, want %d, got %d", tx.ChainId(), parsedTx.ChainId())
+		}
+	}
+}
+
+// TestEIP1559TransactionJSON tests serializing/de-serializing to/from JSON.
+func TestEIP1559TransactionJSON(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("could not generate key: %v", err)
+	}
+	signer := NewEIP155Signer(common.Big1)
+
+	transactions := make([]*Transaction, 0, 50)
+	for i := uint64(0); i < 25; i++ {
+		var tx *Transaction
+		switch i % 2 {
+		case 0:
+			tx = NewTransaction(i, common.Address{1}, common.Big0, 1, nil, []byte("abcdef"), big.NewInt(200000), big.NewInt(800000))
+		case 1:
+			tx = NewContractCreation(i, common.Big0, 1, nil, []byte("abcdef"), big.NewInt(200000), big.NewInt(800000))
 		}
 		transactions = append(transactions, tx)
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -91,6 +91,7 @@ type Context struct {
 	BlockNumber *big.Int       // Provides information for NUMBER
 	Time        *big.Int       // Provides information for TIME
 	Difficulty  *big.Int       // Provides information for DIFFICULTY
+	BaseFee     *big.Int       // Provides information for BASEFEE
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -491,6 +493,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			}
 		}()
 	}
+	var gp1559 *core.GasPool
 	// Feed the transactions into the tracers and return
 	var failed error
 	for i, tx := range txs {
@@ -501,8 +504,11 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		msg, _ := tx.AsMessage(signer)
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
+		if api.eth.blockchain.Config().IsEIP1559(block.Number()) {
+			gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+		}
 		vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vm.Config{})
-		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
+		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), gp1559); err != nil {
 			failed = err
 			break
 		}
@@ -563,6 +569,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	var (
 		signer = types.MakeSigner(api.eth.blockchain.Config(), block.Number())
 		dumps  []string
+		gp1559 *core.GasPool
 	)
 	for i, tx := range block.Transactions() {
 		// Prepare the trasaction for un-traced execution
@@ -596,7 +603,10 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vmConf)
-		_, _, _, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
+		if api.eth.blockchain.Config().IsEIP1559(block.Number()) {
+			gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+		}
+		_, _, _, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), gp1559)
 		if writer != nil {
 			writer.Flush()
 		}
@@ -727,7 +737,11 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	var (
 		tracer vm.Tracer
 		err    error
+		gp1559 *core.GasPool
 	)
+	if api.eth.blockchain.Config().IsEIP1559(vmctx.BlockNumber) {
+		gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
 	switch {
 	case config != nil && config.Tracer != nil:
 		// Define a meaningful timeout of a single transaction trace
@@ -758,7 +772,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vm.Config{Debug: true, Tracer: tracer})
 
-	ret, gas, failed, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()))
+	ret, gas, failed, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), gp1559)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
 	}
@@ -810,9 +824,13 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 		if idx == txIndex {
 			return msg, context, statedb, nil
 		}
+		var gp1559 *core.GasPool
+		if api.eth.blockchain.Config().IsEIP1559(block.Number()) {
+			gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, statedb, api.eth.blockchain.Config(), vm.Config{})
-		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()), gp1559); err != nil {
 			return nil, vm.Context{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -127,7 +127,7 @@ func (tc *testChain) generate(n int, seed byte, parent *types.Block, heavy bool)
 		// Include transactions to the miner to make blocks more interesting.
 		if parent == tc.genesis && i%22 == 0 {
 			signer := types.MakeSigner(params.TestChainConfig, block.Number())
-			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, nil, nil), signer, testKey)
+			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, testKey)
 			if err != nil {
 				panic(err)
 			}

--- a/eth/fetcher/fetcher_test.go
+++ b/eth/fetcher/fetcher_test.go
@@ -52,7 +52,7 @@ func makeChain(n int, seed byte, parent *types.Block) ([]common.Hash, map[common
 		// If the block number is multiple of 3, send a bonus transaction to the miner
 		if parent == genesis && i%3 == 0 {
 			signer := types.MakeSigner(params.TestChainConfig, block.Number())
-			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, nil, nil), signer, testKey)
+			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, testKey)
 			if err != nil {
 				panic(err)
 			}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -227,11 +227,11 @@ func TestPendingTxFilter(t *testing.T) {
 		api        = NewPublicFilterAPI(backend, false)
 
 		transactions = []*types.Transaction{
-			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
-			types.NewTransaction(1, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
-			types.NewTransaction(2, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
-			types.NewTransaction(3, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
-			types.NewTransaction(4, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
+			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil, nil, nil),
+			types.NewTransaction(1, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil, nil, nil),
+			types.NewTransaction(2, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil, nil, nil),
+			types.NewTransaction(3, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil, nil, nil),
+			types.NewTransaction(4, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil, nil, nil),
 		}
 
 		hashes []common.Hash

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -138,7 +138,7 @@ func TestFilters(t *testing.T) {
 				},
 			}
 			gen.AddUncheckedReceipt(receipt)
-			gen.AddUncheckedTx(types.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil))
+			gen.AddUncheckedTx(types.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil, nil, nil))
 		case 2:
 			receipt := types.NewReceipt(nil, false, 0)
 			receipt.Logs = []*types.Log{
@@ -148,7 +148,7 @@ func TestFilters(t *testing.T) {
 				},
 			}
 			gen.AddUncheckedReceipt(receipt)
-			gen.AddUncheckedTx(types.NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil))
+			gen.AddUncheckedTx(types.NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil, nil, nil))
 
 		case 998:
 			receipt := types.NewReceipt(nil, false, 0)
@@ -159,7 +159,7 @@ func TestFilters(t *testing.T) {
 				},
 			}
 			gen.AddUncheckedReceipt(receipt)
-			gen.AddUncheckedTx(types.NewTransaction(998, common.HexToAddress("0x998"), big.NewInt(998), 998, big.NewInt(998), nil))
+			gen.AddUncheckedTx(types.NewTransaction(998, common.HexToAddress("0x998"), big.NewInt(998), 998, big.NewInt(998), nil, nil, nil))
 		case 999:
 			receipt := types.NewReceipt(nil, false, 0)
 			receipt.Logs = []*types.Log{
@@ -169,7 +169,7 @@ func TestFilters(t *testing.T) {
 				},
 			}
 			gen.AddUncheckedReceipt(receipt)
-			gen.AddUncheckedTx(types.NewTransaction(999, common.HexToAddress("0x999"), big.NewInt(999), 999, big.NewInt(999), nil))
+			gen.AddUncheckedTx(types.NewTransaction(999, common.HexToAddress("0x999"), big.NewInt(999), 999, big.NewInt(999), nil, nil, nil))
 		}
 	})
 	for i, block := range chain {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -286,13 +286,13 @@ func testGetNodeData(t *testing.T, protocol int) {
 		switch i {
 		case 0:
 			// In block 1, the test bank sends account #1 some ether.
-			tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+			tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), signer, testBankKey)
 			block.AddTx(tx)
 		case 1:
 			// In block 2, the test bank sends some more ether to account #1.
 			// acc1Addr passes it on to account #2.
-			tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, testBankKey)
-			tx2, _ := types.SignTx(types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, acc1Key)
+			tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, testBankKey)
+			tx2, _ := types.SignTx(types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, acc1Key)
 			block.AddTx(tx1)
 			block.AddTx(tx2)
 		case 2:
@@ -383,13 +383,13 @@ func testGetReceipt(t *testing.T, protocol int) {
 		switch i {
 		case 0:
 			// In block 1, the test bank sends account #1 some ether.
-			tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+			tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), signer, testBankKey)
 			block.AddTx(tx)
 		case 1:
 			// In block 2, the test bank sends some more ether to account #1.
 			// acc1Addr passes it on to account #2.
-			tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, testBankKey)
-			tx2, _ := types.SignTx(types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, acc1Key)
+			tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil,  nil, nil), signer, testBankKey)
+			tx2, _ := types.SignTx(types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil,  nil, nil), signer, acc1Key)
 			block.AddTx(tx1)
 			block.AddTx(tx2)
 		case 2:

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -388,8 +388,8 @@ func testGetReceipt(t *testing.T, protocol int) {
 		case 1:
 			// In block 2, the test bank sends some more ether to account #1.
 			// acc1Addr passes it on to account #2.
-			tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil,  nil, nil), signer, testBankKey)
-			tx2, _ := types.SignTx(types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil,  nil, nil), signer, acc1Key)
+			tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBank), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, testBankKey)
+			tx2, _ := types.SignTx(types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, acc1Key)
 			block.AddTx(tx1)
 			block.AddTx(tx2)
 		case 2:

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -132,7 +132,7 @@ func (p *testTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subs
 
 // newTestTransaction create a new dummy transaction.
 func newTestTransaction(from *ecdsa.PrivateKey, nonce uint64, datasize int) *types.Transaction {
-	tx := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), 100000, big.NewInt(0), make([]byte, datasize))
+	tx := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), 100000, big.NewInt(0), make([]byte, datasize), nil, nil)
 	tx, _ = types.SignTx(tx, types.HomesteadSigner{}, from)
 	return tx
 }

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -122,7 +122,7 @@ type callTracerTest struct {
 
 func TestPrestateTracerCreate2(t *testing.T) {
 	unsignedTx := types.NewTransaction(1, common.HexToAddress("0x00000000000000000000000000000000deadbeef"),
-		new(big.Int), 5000000, big.NewInt(1), []byte{})
+		new(big.Int), 5000000, big.NewInt(1), []byte{}, nil, nil)
 
 	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -110,6 +110,7 @@ type callContext struct {
 	Time       math.HexOrDecimal64   `json:"timestamp"`
 	GasLimit   math.HexOrDecimal64   `json:"gasLimit"`
 	Miner      common.Address        `json:"miner"`
+	BaseFee    *math.HexOrDecimal256 `json:"baseFee"`
 }
 
 // callTracerTest defines a single test to check the call tracer against.
@@ -181,7 +182,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()), nil)
 	if _, _, _, err = st.TransitionDb(); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
@@ -241,6 +242,7 @@ func TestCallTracer(t *testing.T) {
 				Difficulty:  (*big.Int)(test.Context.Difficulty),
 				GasLimit:    uint64(test.Context.GasLimit),
 				GasPrice:    tx.GasPrice(),
+				BaseFee:     (*big.Int)(test.Context.BaseFee),
 			}
 			statedb := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc)
 
@@ -255,7 +257,11 @@ func TestCallTracer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
-			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+			var gp1559 *core.GasPool
+			if test.Genesis.Config.IsEIP1559(context.BlockNumber) {
+				gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+			}
+			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()), gp1559)
 			if _, _, _, err = st.TransitionDb(); err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -534,5 +534,11 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasPrice != nil {
 		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
 	}
+	if msg.GasPremium != nil {
+		arg["gasPremium"] = (*hexutil.Big)(msg.GasPremium)
+	}
+	if msg.FeeCap != nil {
+		arg["feeCap"] = (*hexutil.Big)(msg.FeeCap)
+	}
 	return arg
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -113,12 +113,14 @@ type ChainSyncReader interface {
 
 // CallMsg contains parameters for contract calls.
 type CallMsg struct {
-	From     common.Address  // the sender of the 'transaction'
-	To       *common.Address // the destination contract (nil for contract creation)
-	Gas      uint64          // if 0, the call executes with near-infinite gas
-	GasPrice *big.Int        // wei <-> gas exchange ratio
-	Value    *big.Int        // amount of wei sent along with the call
-	Data     []byte          // input data, usually an ABI-encoded contract method invocation
+	From       common.Address  // the sender of the 'transaction'
+	To         *common.Address // the destination contract (nil for contract creation)
+	Gas        uint64          // if 0, the call executes with near-infinite gas
+	GasPrice   *big.Int        // wei <-> gas exchange ratio
+	Value      *big.Int        // amount of wei sent along with the call
+	Data       []byte          // input data, usually an ABI-encoded contract method invocation
+	GasPremium *big.Int        // EIP1559 gas premium paid to miners (excess of the basefee)
+	FeeCap     *big.Int        // Max amount of gas we can use for this trx execution
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1045,6 +1045,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"timestamp":        hexutil.Uint64(head.Time),
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
+		"baseFee":          (*hexutil.Big)(head.BaseFee),
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1425,9 +1425,9 @@ func (args *SendTxArgs) toTransaction() *types.Transaction {
 		input = *args.Data
 	}
 	if args.To == nil {
-		return types.NewContractCreation(uint64(*args.Nonce), (*big.Int)(args.Value), uint64(*args.Gas), (*big.Int)(args.GasPrice), input)
+		return types.NewContractCreation(uint64(*args.Nonce), (*big.Int)(args.Value), uint64(*args.Gas), (*big.Int)(args.GasPrice), input, nil, nil)
 	}
-	return types.NewTransaction(uint64(*args.Nonce), *args.To, (*big.Int)(args.Value), uint64(*args.Gas), (*big.Int)(args.GasPrice), input)
+	return types.NewTransaction(uint64(*args.Nonce), *args.To, (*big.Int)(args.Value), uint64(*args.Gas), (*big.Int)(args.GasPrice), input, nil, nil)
 }
 
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1093,6 +1093,8 @@ type RPCTransaction struct {
 	To               *common.Address `json:"to"`
 	TransactionIndex *hexutil.Uint64 `json:"transactionIndex"`
 	Value            *hexutil.Big    `json:"value"`
+	GasPremium       *hexutil.Big    `json:"gasPremium"`
+	FeeCap           *hexutil.Big    `json:"feeCap"`
 	V                *hexutil.Big    `json:"v"`
 	R                *hexutil.Big    `json:"r"`
 	S                *hexutil.Big    `json:"s"`
@@ -1109,17 +1111,19 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	v, r, s := tx.RawSignatureValues()
 
 	result := &RPCTransaction{
-		From:     from,
-		Gas:      hexutil.Uint64(tx.Gas()),
-		GasPrice: (*hexutil.Big)(tx.GasPrice()),
-		Hash:     tx.Hash(),
-		Input:    hexutil.Bytes(tx.Data()),
-		Nonce:    hexutil.Uint64(tx.Nonce()),
-		To:       tx.To(),
-		Value:    (*hexutil.Big)(tx.Value()),
-		V:        (*hexutil.Big)(v),
-		R:        (*hexutil.Big)(r),
-		S:        (*hexutil.Big)(s),
+		From:       from,
+		Gas:        hexutil.Uint64(tx.Gas()),
+		GasPrice:   (*hexutil.Big)(tx.GasPrice()),
+		Hash:       tx.Hash(),
+		Input:      hexutil.Bytes(tx.Data()),
+		Nonce:      hexutil.Uint64(tx.Nonce()),
+		To:         tx.To(),
+		Value:      (*hexutil.Big)(tx.Value()),
+		GasPremium: (*hexutil.Big)(tx.GasPremium()),
+		FeeCap:     (*hexutil.Big)(tx.FeeCap()),
+		V:          (*hexutil.Big)(v),
+		R:          (*hexutil.Big)(r),
+		S:          (*hexutil.Big)(s),
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = &blockHash

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -828,7 +828,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	}
 
 	// Create new call message
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, false)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, false, nil, nil)
 
 	// Setup context so it may be cancelled the call has completed
 	// or, in case of unmetered gas, setup a context with a timeout.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -763,14 +763,14 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 
 	// EIP1559 guards
-	if b.ChainConfig().IsEIP1559Finalized(b.CurrentBlock().Number()) && args.GasPremium == nil || args.FeeCap == nil || args.GasPrice != nil {
-		return nil, 0, false, fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", b.ChainConfig().EIP1559FinalizedBlock.Uint64())
+	if b.ChainConfig().IsEIP1559Finalized(b.CurrentBlock().Number()) && (args.GasPremium == nil || args.FeeCap == nil || args.GasPrice != nil) {
+		return nil, 0, false, core.ErrTxNotEIP1559
 	}
-	if !b.ChainConfig().IsEIP1559(b.CurrentBlock().Number()) && args.GasPremium != nil || args.FeeCap != nil || args.GasPrice == nil {
-		return nil, 0, false, fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", b.ChainConfig().EIP1559Block.Uint64())
+	if !b.ChainConfig().IsEIP1559(b.CurrentBlock().Number()) && (args.GasPremium != nil || args.FeeCap != nil || args.GasPrice == nil) {
+		return nil, 0, false, core.ErrTxIsEIP1559
 	}
 	if args.GasPrice != nil && (args.GasPremium != nil || args.FeeCap != nil) {
-		return nil, 0, false, errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+		return nil, 0, false, core.ErrTxSetsLegacyAndEIP1559Fields
 	}
 	if args.FeeCap != nil && args.GasPremium == nil {
 		return nil, 0, false, errors.New("if FeeCap is set, GasPremium must be set")
@@ -1395,14 +1395,14 @@ type SendTxArgs struct {
 // setDefaults is a helper function that fills in default values for unspecified tx fields.
 func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	// EIP1559 guards
-	if b.ChainConfig().IsEIP1559Finalized(b.CurrentBlock().Number()) && args.GasPremium == nil || args.FeeCap == nil || args.GasPrice != nil {
-		return fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", b.ChainConfig().EIP1559FinalizedBlock.Uint64())
+	if b.ChainConfig().IsEIP1559Finalized(b.CurrentBlock().Number()) && (args.GasPremium == nil || args.FeeCap == nil || args.GasPrice != nil) {
+		return core.ErrTxNotEIP1559
 	}
-	if !b.ChainConfig().IsEIP1559(b.CurrentBlock().Number()) && args.GasPremium != nil || args.FeeCap != nil || args.GasPrice == nil {
-		return fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", b.ChainConfig().EIP1559Block.Uint64())
+	if !b.ChainConfig().IsEIP1559(b.CurrentBlock().Number()) && (args.GasPremium != nil || args.FeeCap != nil || args.GasPrice == nil) {
+		return core.ErrTxIsEIP1559
 	}
 	if args.GasPrice != nil && (args.GasPremium != nil || args.FeeCap != nil) {
-		return errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+		return core.ErrTxSetsLegacyAndEIP1559Fields
 	}
 	if args.FeeCap != nil && args.GasPremium == nil {
 		return errors.New("if FeeCap is set, GasPremium must be set")
@@ -1559,20 +1559,17 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 		return common.Hash{}, err
 	}
 	// EIP1559 guards
-	if s.b.ChainConfig().IsEIP1559Finalized(s.b.CurrentBlock().Number()) && tx.GasPremium() == nil || tx.FeeCap() == nil || tx.GasPrice() != nil {
-		return common.Hash{}, fmt.Errorf("after block %d EIP1559 is finalized and transactions must contain a GasPremium and FeeCap and not contain a GasPrice", s.b.ChainConfig().EIP1559FinalizedBlock.Uint64())
+	if s.b.ChainConfig().IsEIP1559Finalized(s.b.CurrentBlock().Number()) && (tx.GasPremium() == nil || tx.FeeCap() == nil || tx.GasPrice() != nil) {
+		return common.Hash{}, core.ErrTxNotEIP1559
 	}
-	if !s.b.ChainConfig().IsEIP1559(s.b.CurrentBlock().Number()) && tx.GasPremium() != nil || tx.FeeCap() != nil || tx.GasPrice() == nil {
-		return common.Hash{}, fmt.Errorf("before block %d EIP1559 is not activated and transactions must contain a GasPrice and not contain a GasPremium or FeeCap", s.b.ChainConfig().EIP1559Block.Uint64())
+	if !s.b.ChainConfig().IsEIP1559(s.b.CurrentBlock().Number()) && (tx.GasPremium() != nil || tx.FeeCap() != nil || tx.GasPrice() == nil) {
+		return common.Hash{}, core.ErrTxIsEIP1559
 	}
 	if tx.GasPrice() != nil && (tx.GasPremium() != nil || tx.FeeCap() != nil) {
-		return common.Hash{}, errors.New("if GasPrice is set, GasPremium and FeeCap must not be set")
+		return common.Hash{}, core.ErrTxSetsLegacyAndEIP1559Fields
 	}
-	if tx.FeeCap() != nil && tx.GasPremium() == nil {
-		return common.Hash{}, errors.New("if FeeCap is set, GasPremium must be set")
-	}
-	if tx.GasPremium() != nil && tx.FeeCap() == nil {
-		return common.Hash{}, errors.New("if GasPremium is set, FeeCap must be set")
+	if tx.GasPrice() == nil && (tx.GasPremium() == nil || tx.FeeCap() == nil) {
+		return common.Hash{}, core.ErrMissingGasFields
 	}
 	return SubmitTransaction(ctx, s.b, tx)
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -880,7 +880,11 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
-	res, gas, failed, err := core.ApplyMessage(evm, msg, gp)
+	var gp1559 *core.GasPool
+	if evm.ChainConfig().IsEIP1559(header.Number) {
+		gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
+	res, gas, failed, err := core.ApplyMessage(evm, msg, gp, gp1559)
 	if err := vmError(); err != nil {
 		return nil, 0, false, err
 	}

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -180,7 +180,7 @@ func (b *benchmarkTxSend) init(h *serverHandler, count int) error {
 	for i := range b.txs {
 		data := make([]byte, txSizeCostLimit)
 		rand.Read(data)
-		tx, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), data), signer, key)
+		tx, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), data, nil, nil), signer, key)
 		if err != nil {
 			panic(err)
 		}

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -538,16 +538,16 @@ func testTransactionStatus(t *testing.T, protocol int) {
 	signer := types.HomesteadSigner{}
 
 	// test error status by sending an underpriced transaction
-	tx0, _ := types.SignTx(types.NewTransaction(0, userAddr1, big.NewInt(10000), params.TxGas, nil, nil), signer, bankKey)
+	tx0, _ := types.SignTx(types.NewTransaction(0, userAddr1, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), signer, bankKey)
 	test(tx0, true, light.TxStatus{Status: core.TxStatusUnknown, Error: core.ErrUnderpriced.Error()})
 
-	tx1, _ := types.SignTx(types.NewTransaction(0, userAddr1, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, bankKey)
+	tx1, _ := types.SignTx(types.NewTransaction(0, userAddr1, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil, nil, nil), signer, bankKey)
 	test(tx1, false, light.TxStatus{Status: core.TxStatusUnknown}) // query before sending, should be unknown
 	test(tx1, true, light.TxStatus{Status: core.TxStatusPending})  // send valid processable tx, should return pending
 	test(tx1, true, light.TxStatus{Status: core.TxStatusPending})  // adding it again should not return an error
 
-	tx2, _ := types.SignTx(types.NewTransaction(1, userAddr1, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, bankKey)
-	tx3, _ := types.SignTx(types.NewTransaction(2, userAddr1, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, bankKey)
+	tx2, _ := types.SignTx(types.NewTransaction(1, userAddr1, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil, nil, nil), signer, bankKey)
+	tx3, _ := types.SignTx(types.NewTransaction(2, userAddr1, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil, nil, nil), signer, bankKey)
 	// send transactions in the wrong order, tx3 should be queued
 	test(tx3, true, light.TxStatus{Status: core.TxStatusQueued})
 	test(tx2, true, light.TxStatus{Status: core.TxStatusPending})

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -128,7 +128,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 				from := statedb.GetOrNewStateObject(bankAddr)
 				from.SetBalance(math.MaxBig256)
 
-				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), data, false)}
+				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), data, false, nil, nil)}
 
 				context := core.NewEVMContext(msg, header, bc, nil)
 				vmenv := vm.NewEVM(context, statedb, config, vm.Config{})
@@ -142,7 +142,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			header := lc.GetHeaderByHash(bhash)
 			state := light.NewState(ctx, header, lc.Odr())
 			state.SetBalance(bankAddr, math.MaxBig256)
-			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), data, false)}
+			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), data, false, nil, nil)}
 			context := core.NewEVMContext(msg, header, lc, nil)
 			vmenv := vm.NewEVM(context, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -135,7 +135,11 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
-				ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
+				var gp1559 *core.GasPool
+				if config.IsEIP1559(header.Number) {
+					gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+				}
+				ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp, gp1559)
 				res = append(res, ret...)
 			}
 		} else {
@@ -146,7 +150,11 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			context := core.NewEVMContext(msg, header, lc, nil)
 			vmenv := vm.NewEVM(context, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
-			ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
+			var gp1559 *core.GasPool
+			if config.IsEIP1559(header.Number) {
+				gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+			}
+			ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp, gp1559)
 			if state.Error() == nil {
 				res = append(res, ret...)
 			}

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -111,43 +111,43 @@ func prepare(n int, backend *backends.SimulatedBackend) {
 			registrarAddr, _, _, _ = contract.DeployCheckpointOracle(bind.NewKeyedTransactor(bankKey), backend, []common.Address{signerAddr}, sectionSize, processConfirms, big.NewInt(1))
 			// bankUser transfers some ether to user1
 			nonce, _ := backend.PendingNonceAt(ctx, bankAddr)
-			tx, _ := types.SignTx(types.NewTransaction(nonce, userAddr1, big.NewInt(10000), params.TxGas, nil, nil), signer, bankKey)
+			tx, _ := types.SignTx(types.NewTransaction(nonce, userAddr1, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), signer, bankKey)
 			backend.SendTransaction(ctx, tx)
 		case 1:
 			bankNonce, _ := backend.PendingNonceAt(ctx, bankAddr)
 			userNonce1, _ := backend.PendingNonceAt(ctx, userAddr1)
 
 			// bankUser transfers more ether to user1
-			tx1, _ := types.SignTx(types.NewTransaction(bankNonce, userAddr1, big.NewInt(1000), params.TxGas, nil, nil), signer, bankKey)
+			tx1, _ := types.SignTx(types.NewTransaction(bankNonce, userAddr1, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, bankKey)
 			backend.SendTransaction(ctx, tx1)
 
 			// user1 relays ether to user2
-			tx2, _ := types.SignTx(types.NewTransaction(userNonce1, userAddr2, big.NewInt(1000), params.TxGas, nil, nil), signer, userKey1)
+			tx2, _ := types.SignTx(types.NewTransaction(userNonce1, userAddr2, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, userKey1)
 			backend.SendTransaction(ctx, tx2)
 
 			// user1 deploys a test contract
-			tx3, _ := types.SignTx(types.NewContractCreation(userNonce1+1, big.NewInt(0), 200000, big.NewInt(0), testContractCode), signer, userKey1)
+			tx3, _ := types.SignTx(types.NewContractCreation(userNonce1+1, big.NewInt(0), 200000, big.NewInt(0), testContractCode, nil, nil), signer, userKey1)
 			backend.SendTransaction(ctx, tx3)
 			testContractAddr = crypto.CreateAddress(userAddr1, userNonce1+1)
 
 			// user1 deploys a event contract
-			tx4, _ := types.SignTx(types.NewContractCreation(userNonce1+2, big.NewInt(0), 200000, big.NewInt(0), testEventEmitterCode), signer, userKey1)
+			tx4, _ := types.SignTx(types.NewContractCreation(userNonce1+2, big.NewInt(0), 200000, big.NewInt(0), testEventEmitterCode, nil, nil), signer, userKey1)
 			backend.SendTransaction(ctx, tx4)
 		case 2:
 			// bankUser transfer some ether to signer
 			bankNonce, _ := backend.PendingNonceAt(ctx, bankAddr)
-			tx1, _ := types.SignTx(types.NewTransaction(bankNonce, signerAddr, big.NewInt(1000000000), params.TxGas, nil, nil), signer, bankKey)
+			tx1, _ := types.SignTx(types.NewTransaction(bankNonce, signerAddr, big.NewInt(1000000000), params.TxGas, nil, nil, nil, nil), signer, bankKey)
 			backend.SendTransaction(ctx, tx1)
 
 			// invoke test contract
 			data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001")
-			tx2, _ := types.SignTx(types.NewTransaction(bankNonce+1, testContractAddr, big.NewInt(0), 100000, nil, data), signer, bankKey)
+			tx2, _ := types.SignTx(types.NewTransaction(bankNonce+1, testContractAddr, big.NewInt(0), 100000, nil, data, nil, nil), signer, bankKey)
 			backend.SendTransaction(ctx, tx2)
 		case 3:
 			// invoke test contract
 			bankNonce, _ := backend.PendingNonceAt(ctx, bankAddr)
 			data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002")
-			tx, _ := types.SignTx(types.NewTransaction(bankNonce, testContractAddr, big.NewInt(0), 100000, nil, data), signer, bankKey)
+			tx, _ := types.SignTx(types.NewTransaction(bankNonce, testContractAddr, big.NewInt(0), 100000, nil, data, nil, nil), signer, bankKey)
 			backend.SendTransaction(ctx, tx)
 		}
 		backend.Commit()

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -194,7 +194,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 
 		// Perform read-only call.
 		st.SetBalance(testBankAddress, math.MaxBig256)
-		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), data, false)}
+		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), data, false, nil, nil)}
 		context := core.NewEVMContext(msg, header, chain, nil)
 		vmenv := vm.NewEVM(context, st, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -212,17 +212,17 @@ func testChainGen(i int, block *core.BlockGen) {
 	switch i {
 	case 0:
 		// In block 1, the test bank sends account #1 some ether.
-		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), signer, testBankKey)
 		block.AddTx(tx)
 	case 1:
 		// In block 2, the test bank sends some more ether to account #1.
 		// acc1Addr passes it on to account #2.
 		// acc1Addr creates a test contract.
-		tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, testBankKey)
+		tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, testBankKey)
 		nonce := block.TxNonce(acc1Addr)
-		tx2, _ := types.SignTx(types.NewTransaction(nonce, acc2Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, acc1Key)
+		tx2, _ := types.SignTx(types.NewTransaction(nonce, acc2Addr, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), signer, acc1Key)
 		nonce++
-		tx3, _ := types.SignTx(types.NewContractCreation(nonce, big.NewInt(0), 1000000, big.NewInt(0), testContractCode), signer, acc1Key)
+		tx3, _ := types.SignTx(types.NewContractCreation(nonce, big.NewInt(0), 1000000, big.NewInt(0), testContractCode, nil, nil), signer, acc1Key)
 		testContractAddr = crypto.CreateAddress(acc1Addr, nonce)
 		block.AddTx(tx1)
 		block.AddTx(tx2)
@@ -232,7 +232,7 @@ func testChainGen(i int, block *core.BlockGen) {
 		block.SetCoinbase(acc2Addr)
 		block.SetExtra([]byte("yeehaw"))
 		data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001")
-		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data), signer, testBankKey)
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data, nil, nil), signer, testBankKey)
 		block.AddTx(tx)
 	case 3:
 		// Block 4 includes blocks 2 and 3 as uncle headers (with modified extra data).
@@ -243,7 +243,7 @@ func testChainGen(i int, block *core.BlockGen) {
 		b3.Extra = []byte("foo")
 		block.AddUncle(b3)
 		data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002")
-		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data), signer, testBankKey)
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data, nil, nil), signer, testBankKey)
 		block.AddTx(tx)
 	}
 }

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -198,7 +198,11 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		context := core.NewEVMContext(msg, header, chain, nil)
 		vmenv := vm.NewEVM(context, st, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
-		ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
+		var gp1559 *core.GasPool
+		if config.IsEIP1559(header.Number) {
+			gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+		}
+		ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp, gp1559)
 		res = append(res, ret...)
 		if st.Error() != nil {
 			return res, st.Error()

--- a/light/txpool_test.go
+++ b/light/txpool_test.go
@@ -77,7 +77,7 @@ func txPoolTestChainGen(i int, block *core.BlockGen) {
 
 func TestTxPool(t *testing.T) {
 	for i := range testTx {
-		testTx[i], _ = types.SignTx(types.NewTransaction(uint64(i), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
+		testTx[i], _ = types.SignTx(types.NewTransaction(uint64(i), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil, nil, nil), types.HomesteadSigner{}, testBankKey)
 	}
 
 	var (

--- a/miner/stress_clique.go
+++ b/miner/stress_clique.go
@@ -117,7 +117,7 @@ func main() {
 			panic(err)
 		}
 		// Create a self transaction and inject into the pool
-		tx, err := types.SignTx(types.NewTransaction(nonces[index], crypto.PubkeyToAddress(faucets[index].PublicKey), new(big.Int), 21000, big.NewInt(100000000000), nil), types.HomesteadSigner{}, faucets[index])
+		tx, err := types.SignTx(types.NewTransaction(nonces[index], crypto.PubkeyToAddress(faucets[index].PublicKey), new(big.Int), 21000, big.NewInt(100000000000), nil, nil, nil), types.HomesteadSigner{}, faucets[index])
 		if err != nil {
 			panic(err)
 		}

--- a/miner/stress_ethash.go
+++ b/miner/stress_ethash.go
@@ -113,7 +113,7 @@ func main() {
 			panic(err)
 		}
 		// Create a self transaction and inject into the pool
-		tx, err := types.SignTx(types.NewTransaction(nonces[index], crypto.PubkeyToAddress(faucets[index].PublicKey), new(big.Int), 21000, big.NewInt(100000000000+rand.Int63n(65536)), nil), types.HomesteadSigner{}, faucets[index])
+		tx, err := types.SignTx(types.NewTransaction(nonces[index], crypto.PubkeyToAddress(faucets[index].PublicKey), new(big.Int), 21000, big.NewInt(100000000000+rand.Int63n(65536)), nil, nil, nil), types.HomesteadSigner{}, faucets[index])
 		if err != nil {
 			panic(err)
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -86,6 +86,7 @@ type environment struct {
 	uncles    mapset.Set     // uncle set
 	tcount    int            // tx count in cycle
 	gasPool   *core.GasPool  // available gas used to pack transactions
+	gp1559    *core.GasPool  // available gas used to pack EIP1559 transactions
 
 	header   *types.Header
 	txs      []*types.Transaction
@@ -704,7 +705,7 @@ func (w *worker) updateSnapshot() {
 func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Address) ([]*types.Log, error) {
 	snap := w.current.state.Snapshot()
 
-	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
+	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.gp1559, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
 		return nil, err
@@ -724,10 +725,28 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	if w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit)
 	}
+	if w.chainConfig.IsEIP1559(w.current.header.Number) && w.current.gp1559 == nil {
+		w.current.gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
 
 	var coalescedLogs []*types.Log
 
 	for {
+		// Retrieve the next transaction and abort if all done
+		tx := txs.Peek()
+		if tx == nil {
+			break
+		}
+		// Set which gasPool to use based on the type of transaction
+		var gp *core.GasPool
+		if tx.GasPrice() == nil && tx.GasPremium() != nil && tx.FeeCap() != nil {
+			gp = w.current.gp1559
+		} else if tx.GasPremium() == nil && tx.FeeCap() == nil && tx.GasPrice() != nil {
+			gp = w.current.gasPool
+		} else {
+			continue
+		}
+
 		// In the following three cases, we will interrupt the execution of the transaction.
 		// (1) new head block event arrival, the interrupt signal is 1
 		// (2) worker start or restart, the interrupt signal is 1
@@ -737,7 +756,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		if interrupt != nil && atomic.LoadInt32(interrupt) != commitInterruptNone {
 			// Notify resubmit loop to increase resubmitting interval due to too frequent commits.
 			if atomic.LoadInt32(interrupt) == commitInterruptResubmit {
-				ratio := float64(w.current.header.GasLimit-w.current.gasPool.Gas()) / float64(w.current.header.GasLimit)
+				ratio := float64(w.current.header.GasLimit-gp.Gas()) / float64(w.current.header.GasLimit)
 				if ratio < 0.1 {
 					ratio = 0.1
 				}
@@ -749,13 +768,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			return atomic.LoadInt32(interrupt) == commitInterruptNewHead
 		}
 		// If we don't have enough gas for any further transactions then we're done
-		if w.current.gasPool.Gas() < params.TxGas {
-			log.Trace("Not enough gas for further transactions", "have", w.current.gasPool, "want", params.TxGas)
-			break
-		}
-		// Retrieve the next transaction and abort if all done
-		tx := txs.Peek()
-		if tx == nil {
+		if gp.Gas() < params.TxGas {
+			log.Trace("Not enough gas for further transactions", "have", gp, "want", params.TxGas)
 			break
 		}
 		// Error may be ignored here. The error has already been checked

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -455,7 +455,21 @@ func (w *worker) mainLoop() {
 			// be automatically eliminated.
 			if !w.isRunning() && w.current != nil {
 				// If block is already full, abort
-				if gp := w.current.gasPool; gp != nil && gp.Gas() < params.TxGas {
+				legacyGasPool := w.current.gasPool
+				eip1559GasPool := w.current.gp1559
+				// If EIP1559 is finalized we only accept 1559 transactions so if that pool is exhausted the block is full
+				if w.chainConfig.IsEIP1559Finalized(w.chain.CurrentBlock().Number()) && eip1559GasPool != nil && eip1559GasPool.Gas() < params.TxGas {
+					continue
+				}
+				// If EIP1559 has not been initialized we only accept legacy transaction so if that pool is exhausted the block is full
+				if !w.chainConfig.IsEIP1559(w.chain.CurrentBlock().Number()) && legacyGasPool != nil && legacyGasPool.Gas() < params.TxGas {
+					continue
+				}
+				// When we are between EIP1559 initialization and finalization we can received transactions of both types
+				// and one pool could be exhausted while the other is not
+				// If both pools are exhausted we know the block is full but if only one is we could still accept transactions
+				// of the other type so we need to proceed into commitTransactions()
+				if legacyGasPool != nil && legacyGasPool.Gas() < params.TxGas && eip1559GasPool != nil && eip1559GasPool.Gas() < params.TxGas {
 					continue
 				}
 				w.mu.RLock()
@@ -484,7 +498,7 @@ func (w *worker) mainLoop() {
 			}
 			atomic.AddInt32(&w.newTxs, int32(len(ev.Txs)))
 
-		// System stopped
+			// System stopped
 		case <-w.exitCh:
 			return
 		case <-w.txsSub.Err():
@@ -722,11 +736,15 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		return true
 	}
 
-	if w.current.gasPool == nil {
+	if !w.chainConfig.IsEIP1559Finalized(w.current.header.Number) && w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit)
 	}
 	if w.chainConfig.IsEIP1559(w.current.header.Number) && w.current.gp1559 == nil {
 		w.current.gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
+	oneTxType := false
+	if w.chainConfig.IsEIP1559Finalized(w.current.header.Number) || !w.chainConfig.IsEIP1559(w.current.header.Number) {
+		oneTxType = true
 	}
 
 	var coalescedLogs []*types.Log
@@ -738,12 +756,37 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			break
 		}
 		// Set which gasPool to use based on the type of transaction
+		eip1559 := false
 		var gp *core.GasPool
-		if tx.GasPrice() == nil && tx.GasPremium() != nil && tx.FeeCap() != nil {
+		if w.chainConfig.IsEIP1559(w.current.header.Number) && tx.GasPrice() == nil && tx.GasPremium() != nil && tx.FeeCap() != nil {
 			gp = w.current.gp1559
-		} else if tx.GasPremium() == nil && tx.FeeCap() == nil && tx.GasPrice() != nil {
+			eip1559 = true
+		} else if !w.chainConfig.IsEIP1559Finalized(w.current.header.Number) && tx.GasPremium() == nil && tx.FeeCap() == nil && tx.GasPrice() != nil {
 			gp = w.current.gasPool
 		} else {
+			log.Error("Transaction does not conform with expected format (legacy or EIP1559)")
+			continue
+		}
+
+		// If we processing both types of transactions then we can break if both pools are exhausted
+		if w.current.gasPool != nil && w.current.gasPool.Gas() < params.TxGas && w.current.gp1559 != nil && w.current.gp1559.Gas() < params.TxGas {
+			log.Trace("Not enough gas for further transactions", "have legacy pool", w.current.gasPool, "and eip1559 pool", w.current.gp1559, "want", params.TxGas)
+			break
+		}
+
+		// If we don't have enough gas for any further transactions of this type
+		if gp.Gas() < params.TxGas {
+			if eip1559 {
+				log.Trace("Not enough gas for further EIP1559 transactions", "have", gp, "want", params.TxGas)
+			} else {
+				log.Trace("Not enough gas for further legacy transactions", "have", gp, "want", params.TxGas)
+			}
+			// and this is the only type we are processing, then we're done
+			if oneTxType {
+				break
+			}
+			// Otherwise if only the current pool is exhausted we need to continue
+			// in case some of the subsequent transactions are for the non-exhausted pool
 			continue
 		}
 
@@ -756,7 +799,12 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		if interrupt != nil && atomic.LoadInt32(interrupt) != commitInterruptNone {
 			// Notify resubmit loop to increase resubmitting interval due to too frequent commits.
 			if atomic.LoadInt32(interrupt) == commitInterruptResubmit {
-				ratio := float64(w.current.header.GasLimit-gp.Gas()) / float64(w.current.header.GasLimit)
+				var ratio float64
+				if eip1559 {
+					ratio = float64(params.MaxGasEIP1559-gp.Gas()) / float64(params.MaxGasEIP1559)
+				} else {
+					ratio = float64(w.current.header.GasLimit-gp.Gas()) / float64(w.current.header.GasLimit)
+				}
 				if ratio < 0.1 {
 					ratio = 0.1
 				}
@@ -767,11 +815,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			}
 			return atomic.LoadInt32(interrupt) == commitInterruptNewHead
 		}
-		// If we don't have enough gas for any further transactions then we're done
-		if gp.Gas() < params.TxGas {
-			log.Trace("Not enough gas for further transactions", "have", gp, "want", params.TxGas)
-			break
-		}
+
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance is the transaction pool.
 		//

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -80,9 +80,9 @@ func init() {
 		Period: 10,
 		Epoch:  30000,
 	}
-	tx1, _ := types.SignTx(types.NewTransaction(0, testUserAddress, big.NewInt(1000), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
+	tx1, _ := types.SignTx(types.NewTransaction(0, testUserAddress, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), types.HomesteadSigner{}, testBankKey)
 	pendingTxs = append(pendingTxs, tx1)
-	tx2, _ := types.SignTx(types.NewTransaction(1, testUserAddress, big.NewInt(1000), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
+	tx2, _ := types.SignTx(types.NewTransaction(1, testUserAddress, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), types.HomesteadSigner{}, testBankKey)
 	newTxs = append(newTxs, tx2)
 	rand.Seed(time.Now().UnixNano())
 }
@@ -170,9 +170,9 @@ func (b *testWorkerBackend) newRandomUncle() *types.Block {
 func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 	var tx *types.Transaction
 	if creation {
-		tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(testBankAddress), big.NewInt(0), testGas, nil, common.FromHex(testCode)), types.HomesteadSigner{}, testBankKey)
+		tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(testBankAddress), big.NewInt(0), testGas, nil, common.FromHex(testCode), nil, nil), types.HomesteadSigner{}, testBankKey)
 	} else {
-		tx, _ = types.SignTx(types.NewTransaction(b.txPool.Nonce(testBankAddress), testUserAddress, big.NewInt(1000), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
+		tx, _ = types.SignTx(types.NewTransaction(b.txPool.Nonce(testBankAddress), testUserAddress, big.NewInt(1000), params.TxGas, nil, nil, nil, nil), types.HomesteadSigner{}, testBankKey)
 	}
 	return tx
 }

--- a/mobile/types.go
+++ b/mobile/types.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -199,17 +200,17 @@ type Transaction struct {
 
 // NewContractCreation creates a new transaction for deploying a new contract with
 // the given properties.
-func NewContractCreation(nonce int64, amount *BigInt, gasLimit int64, gasPrice *BigInt, data []byte) *Transaction {
-	return &Transaction{types.NewContractCreation(uint64(nonce), amount.bigint, uint64(gasLimit), gasPrice.bigint, common.CopyBytes(data))}
+func NewContractCreation(nonce int64, amount *BigInt, gasLimit int64, gasPrice *BigInt, data []byte, gasPremium, feeCap *big.Int) *Transaction {
+	return &Transaction{types.NewContractCreation(uint64(nonce), amount.bigint, uint64(gasLimit), gasPrice.bigint, common.CopyBytes(data), gasPremium, feeCap)}
 }
 
 // NewTransaction creates a new transaction with the given properties. Contracts
 // can be created by transacting with a nil recipient.
-func NewTransaction(nonce int64, to *Address, amount *BigInt, gasLimit int64, gasPrice *BigInt, data []byte) *Transaction {
+func NewTransaction(nonce int64, to *Address, amount *BigInt, gasLimit int64, gasPrice *BigInt, data []byte, gasPremium, feeCap *big.Int) *Transaction {
 	if to == nil {
-		return &Transaction{types.NewContractCreation(uint64(nonce), amount.bigint, uint64(gasLimit), gasPrice.bigint, common.CopyBytes(data))}
+		return &Transaction{types.NewContractCreation(uint64(nonce), amount.bigint, uint64(gasLimit), gasPrice.bigint, common.CopyBytes(data), gasPremium, feeCap)}
 	}
-	return &Transaction{types.NewTransaction(uint64(nonce), to.address, amount.bigint, uint64(gasLimit), gasPrice.bigint, common.CopyBytes(data))}
+	return &Transaction{types.NewTransaction(uint64(nonce), to.address, amount.bigint, uint64(gasLimit), gasPrice.bigint, common.CopyBytes(data), gasPremium, feeCap)}
 }
 
 // NewTransactionFromRLP parses a transaction from an RLP data dump.

--- a/params/config.go
+++ b/params/config.go
@@ -54,19 +54,22 @@ var CheckpointOracles = map[common.Hash]*CheckpointOracleConfig{
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(1),
-		HomesteadBlock:      big.NewInt(1150000),
-		DAOForkBlock:        big.NewInt(1920000),
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(2463000),
-		EIP150Hash:          common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
-		EIP155Block:         big.NewInt(2675000),
-		EIP158Block:         big.NewInt(2675000),
-		ByzantiumBlock:      big.NewInt(4370000),
-		ConstantinopleBlock: big.NewInt(7280000),
-		PetersburgBlock:     big.NewInt(7280000),
-		IstanbulBlock:       big.NewInt(9069000),
-		Ethash:              new(EthashConfig),
+		ChainID:               big.NewInt(1),
+		HomesteadBlock:        big.NewInt(1150000),
+		DAOForkBlock:          big.NewInt(1920000),
+		DAOForkSupport:        true,
+		EIP150Block:           big.NewInt(2463000),
+		EIP150Hash:            common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
+		EIP155Block:           big.NewInt(2675000),
+		EIP158Block:           big.NewInt(2675000),
+		ByzantiumBlock:        big.NewInt(4370000),
+		ConstantinopleBlock:   big.NewInt(7280000),
+		PetersburgBlock:       big.NewInt(7280000),
+		IstanbulBlock:         big.NewInt(9069000),
+		EWASMBlock:            nil,
+		EIP1559Block:          nil,
+		EIP1559FinalizedBlock: nil,
+		Ethash:                new(EthashConfig),
 	}
 
 	// MainnetTrustedCheckpoint contains the light client trusted checkpoint for the main network.
@@ -92,19 +95,22 @@ var (
 
 	// TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(3),
-		HomesteadBlock:      big.NewInt(0),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(0),
-		EIP150Hash:          common.HexToHash("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d"),
-		EIP155Block:         big.NewInt(10),
-		EIP158Block:         big.NewInt(10),
-		ByzantiumBlock:      big.NewInt(1700000),
-		ConstantinopleBlock: big.NewInt(4230000),
-		PetersburgBlock:     big.NewInt(4939394),
-		IstanbulBlock:       big.NewInt(6485846),
-		Ethash:              new(EthashConfig),
+		ChainID:               big.NewInt(3),
+		HomesteadBlock:        big.NewInt(0),
+		DAOForkBlock:          nil,
+		DAOForkSupport:        true,
+		EIP150Block:           big.NewInt(0),
+		EIP150Hash:            common.HexToHash("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d"),
+		EIP155Block:           big.NewInt(10),
+		EIP158Block:           big.NewInt(10),
+		ByzantiumBlock:        big.NewInt(1700000),
+		ConstantinopleBlock:   big.NewInt(4230000),
+		PetersburgBlock:       big.NewInt(4939394),
+		IstanbulBlock:         big.NewInt(6485846),
+		EWASMBlock:            nil,
+		EIP1559Block:          nil,
+		EIP1559FinalizedBlock: nil,
+		Ethash:                new(EthashConfig),
 	}
 
 	// TestnetTrustedCheckpoint contains the light client trusted checkpoint for the Ropsten test network.
@@ -130,18 +136,21 @@ var (
 
 	// RinkebyChainConfig contains the chain parameters to run a node on the Rinkeby test network.
 	RinkebyChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(4),
-		HomesteadBlock:      big.NewInt(1),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(2),
-		EIP150Hash:          common.HexToHash("0x9b095b36c15eaf13044373aef8ee0bd3a382a5abb92e402afa44b8249c3a90e9"),
-		EIP155Block:         big.NewInt(3),
-		EIP158Block:         big.NewInt(3),
-		ByzantiumBlock:      big.NewInt(1035301),
-		ConstantinopleBlock: big.NewInt(3660663),
-		PetersburgBlock:     big.NewInt(4321234),
-		IstanbulBlock:       big.NewInt(5435345),
+		ChainID:               big.NewInt(4),
+		HomesteadBlock:        big.NewInt(1),
+		DAOForkBlock:          nil,
+		DAOForkSupport:        true,
+		EIP150Block:           big.NewInt(2),
+		EIP150Hash:            common.HexToHash("0x9b095b36c15eaf13044373aef8ee0bd3a382a5abb92e402afa44b8249c3a90e9"),
+		EIP155Block:           big.NewInt(3),
+		EIP158Block:           big.NewInt(3),
+		ByzantiumBlock:        big.NewInt(1035301),
+		ConstantinopleBlock:   big.NewInt(3660663),
+		PetersburgBlock:       big.NewInt(4321234),
+		IstanbulBlock:         big.NewInt(5435345),
+		EWASMBlock:            nil,
+		EIP1559Block:          nil,
+		EIP1559FinalizedBlock: nil,
 		Clique: &CliqueConfig{
 			Period: 15,
 			Epoch:  30000,
@@ -170,17 +179,20 @@ var (
 
 	// GoerliChainConfig contains the chain parameters to run a node on the Görli test network.
 	GoerliChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(5),
-		HomesteadBlock:      big.NewInt(0),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(0),
-		EIP155Block:         big.NewInt(0),
-		EIP158Block:         big.NewInt(0),
-		ByzantiumBlock:      big.NewInt(0),
-		ConstantinopleBlock: big.NewInt(0),
-		PetersburgBlock:     big.NewInt(0),
-		IstanbulBlock:       big.NewInt(1561651),
+		ChainID:               big.NewInt(5),
+		HomesteadBlock:        big.NewInt(0),
+		DAOForkBlock:          nil,
+		DAOForkSupport:        true,
+		EIP150Block:           big.NewInt(0),
+		EIP155Block:           big.NewInt(0),
+		EIP158Block:           big.NewInt(0),
+		ByzantiumBlock:        big.NewInt(0),
+		ConstantinopleBlock:   big.NewInt(0),
+		PetersburgBlock:       big.NewInt(0),
+		IstanbulBlock:         big.NewInt(1561651),
+		EWASMBlock:            nil,
+		EIP1559Block:          nil,
+		EIP1559FinalizedBlock: nil,
 		Clique: &CliqueConfig{
 			Period: 15,
 			Epoch:  30000,
@@ -213,17 +225,25 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil}
-	TestRules       = TestChainConfig.Rules(new(big.Int))
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil}
+
+	TestRules = TestChainConfig.Rules(new(big.Int))
+
+	// EIP1559 test configs
+	EIP1559ChainConfig          = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, new(EthashConfig), nil}
+	EIP1559FinalizedChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), new(EthashConfig), nil}
+
+	EIP1559TestRules          = EIP1559ChainConfig.Rules(new(big.Int))
+	EIP1559FinalizedTestRules = EIP1559FinalizedChainConfig.Rules(new(big.Int))
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
@@ -288,11 +308,13 @@ type ChainConfig struct {
 	EIP155Block *big.Int `json:"eip155Block,omitempty"` // EIP155 HF block
 	EIP158Block *big.Int `json:"eip158Block,omitempty"` // EIP158 HF block
 
-	ByzantiumBlock      *big.Int `json:"byzantiumBlock,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
-	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
-	PetersburgBlock     *big.Int `json:"petersburgBlock,omitempty"`     // Petersburg switch block (nil = same as Constantinople)
-	IstanbulBlock       *big.Int `json:"istanbulBlock,omitempty"`       // Istanbul switch block (nil = no fork, 0 = already on istanbul)
-	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
+	ByzantiumBlock        *big.Int `json:"byzantiumBlock,omitempty"`        // Byzantium switch block (nil = no fork, 0 = already on byzantium)
+	ConstantinopleBlock   *big.Int `json:"constantinopleBlock,omitempty"`   // Constantinople switch block (nil = no fork, 0 = already activated)
+	PetersburgBlock       *big.Int `json:"petersburgBlock,omitempty"`       // Petersburg switch block (nil = same as Constantinople)
+	IstanbulBlock         *big.Int `json:"istanbulBlock,omitempty"`         // Istanbul switch block (nil = no fork, 0 = already on istanbul)
+	EWASMBlock            *big.Int `json:"ewasmBlock,omitempty"`            // EWASM switch block (nil = no fork, 0 = already activated)
+	EIP1559Block          *big.Int `json:"eip1559Block,omitempty"`          // EIP1559 switch block (nil = no fork, 0 = already on eip1559)
+	EIP1559FinalizedBlock *big.Int `json:"eip1559FinalizedBlock,omitempty"` // EIP1559 finalization switch block (nil = no fork, 0 = already on eip1559 finalized)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`
@@ -329,7 +351,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v EWASM: %v EIP1559: %v EIP1559Finalized: %v Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -341,6 +363,9 @@ func (c *ChainConfig) String() string {
 		c.ConstantinopleBlock,
 		c.PetersburgBlock,
 		c.IstanbulBlock,
+		c.EWASMBlock,
+		c.EIP1559Block,
+		c.EIP1559FinalizedBlock,
 		engine,
 	)
 }
@@ -397,6 +422,16 @@ func (c *ChainConfig) IsEWASM(num *big.Int) bool {
 	return isForked(c.EWASMBlock, num)
 }
 
+// IsEIP1559 returns whether num represents a block number after the EIP1559 fork
+func (c *ChainConfig) IsEIP1559(num *big.Int) bool {
+	return isForked(c.EIP1559Block, num)
+}
+
+// IsEIP1559Finalized returns whether num represents a block number after the EIP1559 finalization fork
+func (c *ChainConfig) IsEIP1559Finalized(num *big.Int) bool {
+	return isForked(c.EIP1559FinalizedBlock, num)
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64) *ConfigCompatError {
@@ -432,6 +467,9 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{"constantinopleBlock", c.ConstantinopleBlock},
 		{"petersburgBlock", c.PetersburgBlock},
 		{"istanbulBlock", c.IstanbulBlock},
+		{"ewasmBlock", c.EWASMBlock},
+		{"eip1559Block", c.EIP1559Block},
+		{"eip1559FinalizedBlock", c.EIP1559FinalizedBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -486,7 +524,13 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 		return newCompatError("Istanbul fork block", c.IstanbulBlock, newcfg.IstanbulBlock)
 	}
 	if isForkIncompatible(c.EWASMBlock, newcfg.EWASMBlock, head) {
-		return newCompatError("ewasm fork block", c.EWASMBlock, newcfg.EWASMBlock)
+		return newCompatError("EWASM fork block", c.EWASMBlock, newcfg.EWASMBlock)
+	}
+	if isForkIncompatible(c.EIP1559Block, newcfg.EIP1559Block, head) {
+		return newCompatError("EIP1559 fork block", c.EIP1559Block, newcfg.EIP1559Block)
+	}
+	if isForkIncompatible(c.EIP1559FinalizedBlock, newcfg.EIP1559FinalizedBlock, head) {
+		return newCompatError("EIP1559Finalized fork block", c.EIP1559FinalizedBlock, newcfg.EIP1559FinalizedBlock)
 	}
 	return nil
 }
@@ -555,6 +599,7 @@ type Rules struct {
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
+	IsEWASM, IsEIP1559, IsEIP1559Finalized                  bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -564,14 +609,17 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		chainID = new(big.Int)
 	}
 	return Rules{
-		ChainID:          new(big.Int).Set(chainID),
-		IsHomestead:      c.IsHomestead(num),
-		IsEIP150:         c.IsEIP150(num),
-		IsEIP155:         c.IsEIP155(num),
-		IsEIP158:         c.IsEIP158(num),
-		IsByzantium:      c.IsByzantium(num),
-		IsConstantinople: c.IsConstantinople(num),
-		IsPetersburg:     c.IsPetersburg(num),
-		IsIstanbul:       c.IsIstanbul(num),
+		ChainID:            new(big.Int).Set(chainID),
+		IsHomestead:        c.IsHomestead(num),
+		IsEIP150:           c.IsEIP150(num),
+		IsEIP155:           c.IsEIP155(num),
+		IsEIP158:           c.IsEIP158(num),
+		IsByzantium:        c.IsByzantium(num),
+		IsConstantinople:   c.IsConstantinople(num),
+		IsPetersburg:       c.IsPetersburg(num),
+		IsIstanbul:         c.IsIstanbul(num),
+		IsEWASM:            c.IsEWASM(num),
+		IsEIP1559:          c.IsEIP1559(num),
+		IsEIP1559Finalized: c.IsEIP1559Finalized(num),
 	}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -129,6 +129,16 @@ const (
 	Bn256PairingBaseGasIstanbul      uint64 = 45000  // Base price for an elliptic curve pairing check
 	Bn256PairingPerPointGasByzantium uint64 = 80000  // Byzantium per-point price for an elliptic curve pairing check
 	Bn256PairingPerPointGasIstanbul  uint64 = 34000  // Per-point price for an elliptic curve pairing check
+
+	EIP1559InitialBaseFee           uint64 = 1000000000 // Wei used as the initial BaseFee
+	EIP1559ForkBlockNumber          uint64 = 100000000  // TBD
+	EIP1559ForkFinalizedBlockNumber        = EIP1559ForkBlockNumber + (MaxGasEIP1559 / (10 * SlackCoefficient))
+	BaseFeeMaxChangeDenominator     uint64 = 8
+	SlackCoefficient                uint64 = 2
+	TargetGasUsed                   uint64 = 8000000
+	MaxGasEIP1559                          = SlackCoefficient * TargetGasUsed
+	EIP1559DecayRange                      = EIP1559ForkFinalizedBlockNumber - EIP1559ForkBlockNumber
+	EIP1559GasIncrementAmount              = (MaxGasEIP1559 / 2) / EIP1559DecayRange // We need to shift (MaxGasEIP1559 / 2) gas from the legacy pool into the EIP1559 pool over the EIP1559DecayRange
 )
 
 var (

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -42,10 +42,10 @@ var (
 	ErrElemTooLarge     = errors.New("rlp: element is larger than containing list")
 	ErrValueTooLarge    = errors.New("rlp: value size exceeds available input length")
 	ErrMoreThanOneValue = errors.New("rlp: input contains more than one value")
+	ErrNotAtEOL         = errors.New("rlp: call of ListEnd not positioned at EOL")
 
 	// internal errors
 	errNotInList     = errors.New("rlp: call of ListEnd outside of any list")
-	errNotAtEOL      = errors.New("rlp: call of ListEnd not positioned at EOL")
 	errUintOverflow  = errors.New("rlp: uint overflow")
 	errNoPointer     = errors.New("rlp: interface given to Decode must be a pointer")
 	errDecodeIntoNil = errors.New("rlp: pointer given to Decode must not be nil")
@@ -129,7 +129,7 @@ func wrapStreamError(err error, typ reflect.Type) error {
 		return &decodeError{msg: "expected input string or byte", typ: typ}
 	case errUintOverflow:
 		return &decodeError{msg: "input string too long", typ: typ}
-	case errNotAtEOL:
+	case ErrNotAtEOL:
 		return &decodeError{msg: "input list has too many elements", typ: typ}
 	}
 	return err
@@ -730,7 +730,7 @@ func (s *Stream) ListEnd() error {
 	}
 	tos := s.stack[len(s.stack)-1]
 	if tos.pos != tos.size {
-		return errNotAtEOL
+		return ErrNotAtEOL
 	}
 	s.stack = s.stack[:len(s.stack)-1] // pop
 	if len(s.stack) > 0 {
@@ -766,6 +766,7 @@ func (s *Stream) Decode(val interface{}) error {
 		// add decode target type to error so context has more meaning
 		decErr.ctx = append(decErr.ctx, fmt.Sprint("(", rtyp.Elem(), ")"))
 	}
+
 	return err
 }
 

--- a/signer/core/types.go
+++ b/signer/core/types.go
@@ -94,7 +94,7 @@ func (args *SendTxArgs) toTransaction() *types.Transaction {
 		input = *args.Input
 	}
 	if args.To == nil {
-		return types.NewContractCreation(uint64(args.Nonce), (*big.Int)(&args.Value), uint64(args.Gas), (*big.Int)(&args.GasPrice), input)
+		return types.NewContractCreation(uint64(args.Nonce), (*big.Int)(&args.Value), uint64(args.Gas), (*big.Int)(&args.GasPrice), input, nil, nil)
 	}
-	return types.NewTransaction(uint64(args.Nonce), args.To.Address(), (*big.Int)(&args.Value), (uint64)(args.Gas), (*big.Int)(&args.GasPrice), input)
+	return types.NewTransaction(uint64(args.Nonce), args.To.Address(), (*big.Int)(&args.Value), (uint64)(args.Gas), (*big.Int)(&args.GasPrice), input, nil, nil)
 }

--- a/signer/rules/rules_test.go
+++ b/signer/rules/rules_test.go
@@ -458,7 +458,7 @@ func dummySigned(value *big.Int) *types.Transaction {
 	gas := uint64(21000)
 	gasPrice := big.NewInt(2000000)
 	data := make([]byte, 0)
-	return types.NewTransaction(3, to, value, gas, gasPrice, data)
+	return types.NewTransaction(3, to, value, gas, gasPrice, data, nil, nil)
 }
 
 func TestLimitWindow(t *testing.T) {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -181,10 +181,13 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config) (*stat
 	context.GetHash = vmTestBlockHash
 	evm := vm.NewEVM(context, statedb, config, vmconfig)
 
-	gaspool := new(core.GasPool)
-	gaspool.AddGas(block.GasLimit())
+	gaspool := new(core.GasPool).AddGas(block.GasLimit())
+	var gp1559 *core.GasPool
+	if config.IsEIP1559(block.Number()) {
+		gp1559 = new(core.GasPool).AddGas(params.MaxGasEIP1559)
+	}
 	snapshot := statedb.Snapshot()
-	if _, _, _, err := core.ApplyMessage(evm, msg, gaspool); err != nil {
+	if _, _, _, err := core.ApplyMessage(evm, msg, gaspool, gp1559); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
 	// Commit block

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -279,7 +279,7 @@ func (tx *stTransaction) toMessage(ps stPostState) (core.Message, error) {
 		return nil, fmt.Errorf("invalid tx data %q", dataHex)
 	}
 
-	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, data, true)
+	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, data, true, nil, nil)
 	return msg, nil
 }
 


### PR DESCRIPTION
Resolves #5 #6 #7 and #8 

- [x] Add a new field, isEIP1559 to StateTransition in state_transition.go.

- [x] Extract the implementation of buyGas() on StateTransition into a new method, buyGasLegacy(). This method should decrement the legacy gas pool.

- [x] Reimplement buyGas(). buyGas() should call either buyGasLegacy() or buyGasEIP1559() depending on whether isEIP1559 is true and the transaction is of the new type.

- [x] Implement a new method, buyGasEIP1559(), on the StateTransition struct in state_transition.go. This method will perform the new gas price calculation, and decrement gas from the new gas pool.

- [x] Reimplement buyGas(). buyGas() should call either buyGasLegacy() or buyGasEIP1559() depending on whether isEIP1559 is true and the transaction is of the new type.

- [x] Modify StateTransition.TransitionDb() in state_transition.go to correctly calculate the coinbase credit

- [x] Modify Process() on StateProcessor in state_processor.go to set the appropriate GasPool gas limit to MaxGasEIP1559 if the fork is activated.

- [x] Modify commitTransactions() in worker.go to set the appropriate GasPool gas limit to MaxGasEIP1559 if the fork is activated.

- [x] Add EIP1559 field guards